### PR TITLE
Move MiqFS dependency to the test file

### DIFF
--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -1,7 +1,4 @@
 require 'sync'
-
-require 'fs/MiqFS/MiqFS'
-require 'fs/VimDatastoreFS/VimDatastoreFS'
 require 'util/miq-extensions'  # Required patch to open-uri for get_file_content
 
 class MiqVimDataStore
@@ -265,9 +262,6 @@ class MiqVimDataStore
     end
   end
 
-  def getFs
-    (MiqFS.new(VimDatastoreFS, self))
-  end
 
   def dumpProps
     props = @invObj.getMoProp_local(@dsMor, "browser")["browser"]

--- a/test/VMwareWebService/browserTest.rb
+++ b/test/VMwareWebService/browserTest.rb
@@ -2,6 +2,9 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
+require 'fs/MiqFS/MiqFS'
+require 'fs/VimDatastoreFS/VimDatastoreFS'
+
 $vim_log = Logger.new(STDOUT)
 $vim_log.level = Logger::WARN
 
@@ -16,6 +19,10 @@ filePattern = nil
 testPath  = nil
 pathOnly  = false
 recurse   = true
+
+def getFs(ds)
+  (MiqFS.new(VimDatastoreFS, ds))
+end
 
 begin
   vim = MiqVim.new(SERVER, USERNAME, PASSWORD)
@@ -111,7 +118,7 @@ begin
 
   puts "==============================="
   puts "Mounting file system..."
-  fs = vimDs.getFs
+  fs = getFs(vimDs)
   puts "done."
 
   puts "FS Type: #{fs.fsType}"


### PR DESCRIPTION
The getFs() method in `MiqVimDataStore` was only called by `test/browserTest.rb` but was requiring a dependency on `MiqFS` from `manageiq-gems-pending`.  Move the method and requires over to the test file.