### PR TITLE
Remove dependency on miq-hash from gems-pending

### DIFF
--- a/lib/VMwareWebService/MiqVimHost.rb
+++ b/lib/VMwareWebService/MiqVimHost.rb
@@ -3,7 +3,7 @@ require 'sync'
 require 'enumerator'
 require "ostruct"
 
-require 'util/extensions/miq-hash'
+require 'more_core_extensions/core_ext/hash'
 require 'VMwareWebService/MiqHostDatastoreSystem'
 require 'VMwareWebService/MiqHostStorageSystem'
 require 'VMwareWebService/MiqHostFirewallSystem'

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -3,7 +3,7 @@ require 'sync'
 require 'enumerator'
 require "ostruct"
 
-require 'util/extensions/miq-hash'
+require 'more_core_extensions/core_ext/hash'
 require 'active_support/core_ext/object/try'
 
 require 'VMwareWebService/exception'

--- a/test/VMwareWebService/emsRefreshTest.rb
+++ b/test/VMwareWebService/emsRefreshTest.rb
@@ -3,7 +3,7 @@ USE_BROKER = true
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVimBroker'
 require 'VMwareWebService/MiqVim'
-require 'util/extensions/miq-hash'
+require 'more_core_extensions/core_ext/hash'
 require 'util/vmdb-logger'
 
 trap("INT") { exit }

--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ffi-vix_disk_lib",     "~>1.0.3"  # used by VixDiskLib
   spec.add_dependency "handsoap",             "~>0.2.5"
   spec.add_dependency "httpclient",           "~>2.7.1"
+  spec.add_dependency "more_core_extensions", "~>3.2"
   spec.add_dependency "rbvmomi",              "~>1.9.4"
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
A number of files were requiring util/miq-hash but not using any methods
directly.  Replace with more_core_extensions/core_ext/hash.