### PR TITLE
Bump httpclient to ~>2.8.0

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ffi",                  "~>1.9.3"
   spec.add_dependency "ffi-vix_disk_lib",     "~>1.0.3"  # used by VixDiskLib
   spec.add_dependency "handsoap",             "~>0.2.5"
-  spec.add_dependency "httpclient",           "~>2.7.1"
+  spec.add_dependency "httpclient",           "~>2.8.0"
   spec.add_dependency "more_core_extensions", "~>3.2"
   spec.add_dependency "rbvmomi",              "~>1.9.4"
 


### PR DESCRIPTION
httpclient is on `v2.8.3` now so bump the dependency.

Depends on: https://github.com/ManageIQ/manageiq-gems-pending/pull/180