### PR TITLE
Remove log4r from VixDiskLibServer

### DIFF
--- a/lib/VMwareWebService/VixDiskLib/VixDiskLibServer.rb
+++ b/lib/VMwareWebService/VixDiskLib/VixDiskLibServer.rb
@@ -5,7 +5,6 @@
 $LOAD_PATH << File.expand_path(File.join(__dir__, "../.."))
 
 require 'drb/drb'
-require 'log4r'
 require 'time'
 require 'VMwareWebService/VixDiskLib/vdl_wrapper'
 

--- a/lib/VMwareWebService/VixDiskLib/vdl_wrapper.rb
+++ b/lib/VMwareWebService/VixDiskLib/vdl_wrapper.rb
@@ -2,7 +2,6 @@ require 'drb/drb'
 require 'sync'
 require 'ffi-vix_disk_lib/api_wrapper'
 require 'VMwareWebService/VimTypes'
-require 'log4r'
 require 'time'
 
 LOG_FILE    = ENV["LOG_FILE"]


### PR DESCRIPTION
VixDiskLibServer was requiring log4r but not using it.