### PR TITLE
Remove dependency on miq-extensions

### DIFF
--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -1,5 +1,4 @@
 require 'sync'
-require 'util/miq-extensions'  # Required patch to open-uri for get_file_content
 
 class MiqVimDataStore
   attr_reader :accessible, :multipleHostAccess, :name, :dsType, :url, :freeBytes, :capacityBytes, :uncommitted, :invObj


### PR DESCRIPTION
The get_file_content method works without miq-extensions (there is no
patch to open-uri) so it is safe to remove the require.