### PR TITLE
Remove util/vmdb-logger as a dependency

### DIFF
--- a/test/VMwareWebService/emsRefreshTest.rb
+++ b/test/VMwareWebService/emsRefreshTest.rb
@@ -4,7 +4,7 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVimBroker'
 require 'VMwareWebService/MiqVim'
 require 'more_core_extensions/core_ext/hash'
-require 'util/vmdb-logger'
+require 'logger'
 
 trap("INT") { exit }
 
@@ -19,7 +19,7 @@ VC_ACCESSORS = [
   [:resourcePoolsByMor, :rp],
 ]
 
-$vim_log = VMDBLogger.new("./ems_refresh_test.log") unless USE_BROKER
+$vim_log = Logger.new("./ems_refresh_test.log") unless USE_BROKER
 
 begin
   loop do


### PR DESCRIPTION
Since requiring `util/vmdb-logger` from `manageiq-gems-pending` is not really necessary for the `emsRefreshTest.rb`, use the vanilla ruby Logger instead.  This removes it from being needed entirely in this repo.

QA
--
Not sure myself how this script is run/used, but I am not sure if it is covered in the tests, so it most likely should be tested with this change in place to see if it causes issues, or works just fine.