### PR TITLE
Update RbVmomi gem after PBM fix

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "handsoap",             "~>0.2.5"
   spec.add_dependency "httpclient",           "~>2.8.0"
   spec.add_dependency "more_core_extensions", "~>3.2"
-  spec.add_dependency "rbvmomi",              "~>1.9.4"
+  spec.add_dependency "rbvmomi",              "~>1.11.3"
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Update the RbVmomi gem after https://github.com/vmware/rbvmomi/pull/114 fixed the issue https://github.com/vmware/rbvmomi/issues/113 causing storage policy based management to fail.