### PR TITLE
Autoload the various VimTypes

### DIFF
--- a/lib/vmware_web_service.rb
+++ b/lib/vmware_web_service.rb
@@ -1,0 +1,7 @@
+# When these classes are deserialized in ActiveRecord (e.g. EmsEvent, MiqQueue), they need to be preloaded
+autoload :VimType,   'VMwareWebService/VimTypes'
+autoload :VimHash,   'VMwareWebService/VimTypes'
+autoload :VimArray,  'VMwareWebService/VimTypes'
+autoload :VimString, 'VMwareWebService/VimTypes'
+autoload :VimFault,  'VMwareWebService/VimTypes'
+autoload :VimClass,  'VMwareWebService/VimTypes'


### PR DESCRIPTION
This moves the eager loading of VimTypes.rb in ManageIQ found
[here](https://github.com/ManageIQ/manageiq/blob/93eb4c0afd3c62f43dce86630dd453295300451c/lib/vmdb/initializer.rb#L6-L7)
to this repo.  We eager loaded this file previously in the main repo for two reasons:

1) VimHash, VimArray, etc. objects could be serialized in the miq_queue table
2) VimTypes.rb doesn't follow rails autoload patterns so rails cannot autoload this file when those constants are encountered

Instead, we can autoload VimTypes when these constants are needed.