### PR TITLE
Allow callers to override format for PerfQuery

### DIFF
--- a/lib/VMwareWebService/MiqVimPerfHistory.rb
+++ b/lib/VMwareWebService/MiqVimPerfHistory.rb
@@ -187,7 +187,7 @@ class MiqVimPerfHistory
     pqSpec = VimHash.new('PerfQuerySpec') do |pqs|
       pqs.entity      = ah[:entity]     if ah[:entity]
       pqs.intervalId  = ah[:intervalId]
-      pqs.format      = PerfFormat::Normal
+      pqs.format      = PerfFormat.const_get((ah[:format] || "normal").to_s.capitalize)
 
       pqs.endTime     = ah[:endTime].to_s   if ah[:endTime]
       pqs.startTime   = ah[:startTime].to_s if ah[:startTime]


### PR DESCRIPTION
There are two options for format for the PerfQuery method, normal and
csv.  Allow the caller to specifiy which format they want instead of
forcing normal.