### PR TITLE
Add client side DrbMessage#load checks

### DIFF
--- a/lib/VMwareWebService/MiqVimBroker.rb
+++ b/lib/VMwareWebService/MiqVimBroker.rb
@@ -38,6 +38,8 @@ class MiqVimBroker
       require 'httpclient'  # needed for exception classes
       require 'VMwareWebService/MiqVimDump'
       require 'VMwareWebService/MiqVimVdlMod'
+      require 'VMwareWebService/MiqVimDrbDebug'
+
       #
       # Modify the meta-class of DRb::DRbObject
       # so we can alias class methods

--- a/lib/VMwareWebService/MiqVimDrbDebug.rb
+++ b/lib/VMwareWebService/MiqVimDrbDebug.rb
@@ -1,0 +1,36 @@
+module DRb
+  class DRbMessage
+    def load(soc)  # :nodoc:
+      begin
+        sz = soc.read(4)        # sizeof (N)
+      rescue
+        raise(DRbConnError, $!.message, $!.backtrace)
+      end
+      raise(DRbConnError, 'connection closed') if sz.nil?
+      raise(DRbConnError, 'premature header') if sz.size < 4
+      sz = sz.unpack('N')[0]
+      raise(DRbConnError, "too large packet #{sz}") if @load_limit < sz
+      begin
+        str = soc.read(sz)
+      rescue
+        raise(DRbConnError, $!.message, $!.backtrace)
+      end
+      raise(DRbConnError, 'connection closed') if str.nil?
+      raise(DRbConnError, 'premature marshal format(can\'t read)') if str.size < sz
+      DRb.mutex.synchronize do
+        begin
+          save = Thread.current[:drb_untaint]
+          Thread.current[:drb_untaint] = []
+          Marshal::load(str)
+        rescue NameError, ArgumentError
+          DRbUnknown.new($!, str)
+        ensure
+          Thread.current[:drb_untaint].each do |x|
+            x.untaint
+          end
+          Thread.current[:drb_untaint] = save
+        end
+      end
+    end
+  end
+end

--- a/lib/VMwareWebService/MiqVimDrbDebug.rb
+++ b/lib/VMwareWebService/MiqVimDrbDebug.rb
@@ -24,6 +24,8 @@ module DRb
           Marshal::load(str)
         rescue NameError, ArgumentError
           DRbUnknown.new($!, str)
+        rescue TypeError => err
+          raise TypeError, "#{err}\n#{str.hex_dump}"
         ensure
           Thread.current[:drb_untaint].each do |x|
             x.untaint


### PR DESCRIPTION
Catch TypeError and Packet too large exceptions and print out the full buffer.  This is similar to the server side checks added by https://github.com/ManageIQ/vmware_web_service/pull/17 but on the client side.

Example:
```
TypeError: TypeError: incompatible marshal file format (can't be read) format version 4.8 required; 60.60 0x00000000  04 08 75 3a 13 44 52 62 3a 3a 44 52 62 4f 62 6a  ..u:.DRb::DRbObj
0x00000010  65 63 74 31 04 08 5b 07 49 22 1c 64 72 75 62 79  ect1..[.I".druby
0x00000020  3a 2f 2f 31 32 37 2e 30 2e 30 2e 31 3a 34 30 33  ://127.0.0.1:403
0x00000030  30 33 06 3a 06 45 54 6c 2b 08 d0 e0 9a e0 ad 2a  03.:.ETl+.��.��*

	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/MiqVimDrbDebug.rb:29:in `rescue in block in load'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/MiqVimDrbDebug.rb:35:in `block in load'
	from /usr/lib/ruby/2.3.0/sync.rb:234:in `block in sync_synchronize'
	from /usr/lib/ruby/2.3.0/sync.rb:231:in `handle_interrupt'
	from /usr/lib/ruby/2.3.0/sync.rb:231:in `sync_synchronize'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/MiqVimDrbDebug.rb:20:in `load'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:642:in `recv_reply'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:941:in `recv_reply'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:1254:in `send_message'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:1142:in `block (2 levels) in method_missing'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:1229:in `open'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:1141:in `block in method_missing'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:1160:in `with_friend'
	from /usr/lib/ruby/2.3.0/drb/drb.rb:1140:in `method_missing'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/MiqVimBroker.rb:419:in `getMiqVim'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/miq_fault_tolerant_vim.rb:188:in `_connect_with_broker'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/miq_fault_tolerant_vim.rb:174:in `block in _connect'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/miq_fault_tolerant_vim.rb:86:in `_execute_with_broker'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/miq_fault_tolerant_vim.rb:75:in `_execute'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/miq_fault_tolerant_vim.rb:172:in `_connect'
	from /home/agrare/workspace/redhat/manageiq/plugins/vmware_web_service/lib/VMwareWebService/miq_fault_tolerant_vim.rb:29:in `initialize'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1385038