### PR TITLE
Reconfigure VM: Add / Remove Network Adapters

### DIFF
--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -925,6 +925,20 @@ class MiqVimVm
     ([nil, nil])
   end # def getDeviceKeysByBacking
 
+  def getDeviceKeysByNetwork(networkName)
+    devs = getProp("config.hardware")["config"]["hardware"]["device"]
+    devs.each do |dev|
+      next if !["VirtualVmxnet3","VirtualE1000e","VirtualPCNet32"].include? dev.xsiType
+      next if dev["deviceInfo"]["label"] != networkName
+      controller_key = dev["controllerKey"]
+      key = dev["key"]
+      unitNumber = dev["unitNumber"]
+      return controller_key, key, unitNumber
+    end
+    # controller_key, key, unitNumber
+    ([nil, nil, nil])
+  end
+
   #####################
   # Miq Alarm methods.
   #####################

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -23,6 +23,13 @@ class MiqVimVm
                                   VirtualLsiLogicSASController
                                   ParaVirtualSCSIController
                                 ).freeze
+  VIRTUAL_NICS              = %w( VirtualE1000
+                                  VirtualE1000e
+                                  VirtualPCNet32
+                                  VirtualVmxnet
+                                  VirtualVmxnet2
+                                  VirtualVmxnet3
+                                ).freeze
   MAX_SCSI_DEVICES          = 15
   MAX_SCSI_CONTROLLERS      = 4
 
@@ -925,11 +932,11 @@ class MiqVimVm
     ([nil, nil])
   end # def getDeviceKeysByBacking
 
-  def getDeviceKeysByNetwork(networkName)
-    devs = getProp("config.hardware")["config"]["hardware"]["device"]
-    devs.each do |dev|
-      next if !["VirtualVmxnet3","VirtualE1000e","VirtualPCNet32"].include? dev.xsiType
-      next if dev["deviceInfo"]["label"] != networkName
+  def getDeviceKeysByLabel(deviceLabel)
+    hardware = getHardware()
+    hardware["device"].to_a.each do |dev|
+      next unless VIRTUAL_NICS.include?(dev.xsiType)
+      next unless dev["deviceInfo"]["label"] == deviceLabel
       controller_key = dev["controllerKey"]
       key = dev["key"]
       unitNumber = dev["unitNumber"]

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -21,15 +21,13 @@ class MiqVimVm
   VIRTUAL_SCSI_CONTROLLERS  = %w( VirtualBusLogicController
                                   VirtualLsiLogicController
                                   VirtualLsiLogicSASController
-                                  ParaVirtualSCSIController
-                                ).freeze
+                                  ParaVirtualSCSIController ).freeze
   VIRTUAL_NICS              = %w( VirtualE1000
                                   VirtualE1000e
                                   VirtualPCNet32
                                   VirtualVmxnet
                                   VirtualVmxnet2
-                                  VirtualVmxnet3
-                                ).freeze
+                                  VirtualVmxnet3 ).freeze
   MAX_SCSI_DEVICES          = 15
   MAX_SCSI_CONTROLLERS      = 4
 
@@ -932,18 +930,18 @@ class MiqVimVm
     ([nil, nil])
   end # def getDeviceKeysByBacking
 
-  def getDeviceKeysByLabel(deviceLabel)
-    hardware = getHardware()
+  def getDeviceKeysByLabel(device_label)
+    hardware = getHardware
     hardware["device"].to_a.each do |dev|
       next unless VIRTUAL_NICS.include?(dev.xsiType)
-      next unless dev["deviceInfo"]["label"] == deviceLabel
+      next unless dev["deviceInfo"]["label"] == device_label
       controller_key = dev["controllerKey"]
       key = dev["key"]
-      unitNumber = dev["unitNumber"]
-      return controller_key, key, unitNumber
+      unit_number = dev["unitNumber"]
+      return controller_key, key, unit_number
     end
-    # controller_key, key, unitNumber
-    ([nil, nil, nil])
+    # controller_key, key, unit_number
+    [nil, nil, nil]
   end
 
   #####################


### PR DESCRIPTION
This PR adds the method `getDeviceKeysByLabel` to retrieve the network adapters device keys for the given network adapter label. This method is part of the new functionality added to the Reconfigure VM webpage.

This PR is part of a set of PRs:
https://github.com/ManageIQ/vmware_web_service/pull/25
https://github.com/ManageIQ/manageiq-providers-vmware/pull/163
https://github.com/ManageIQ/manageiq/pull/16700
https://github.com/ManageIQ/manageiq-ui-classic/pull/3121

More info: https://github.com/ManageIQ/manageiq-ui-classic/issues/3119