### PR TITLE
Add VM UUID to event payload

### DIFF
--- a/lib/VMwareWebService/MiqVimEventMonitor.rb
+++ b/lib/VMwareWebService/MiqVimEventMonitor.rb
@@ -120,7 +120,10 @@ class MiqVimEventMonitor < MiqVimInventory
         next unless (eventVmObj = event[vmStr])
         addVirtualMachine(eventVmObj['vm']) if ADD_VM_EVENTS.include?(event['eventType'])
         next unless (vmObj = virtualMachinesByMor_locked[eventVmObj['vm']])
+
         eventVmObj['path'] = vmObj['summary']['config']['vmPathName']
+        eventVmObj['uuid'] = vmObj['summary']['config']['uuid']
+
         removeVirtualMachine(eventVmObj['vm']) if event['eventType'] == 'VmRemovedEvent'
       end
     end

--- a/lib/VMwareWebService/VimPropMaps.rb
+++ b/lib/VMwareWebService/VimPropMaps.rb
@@ -551,6 +551,7 @@ module VimPropMaps
       :baseName => "@virtualMachines",
       :keyPath  => ['summary', 'config', 'vmPathName'],
       :props    => [
+        "summary.config.uuid",
         "summary.config.vmPathName",
         "summary.runtime.host"
       ]


### PR DESCRIPTION
When a VM is disconnected the VM's UUID is the only property which can
be used to link the VM to other entities e.g. events.

https://bugzilla.redhat.com/show_bug.cgi?id=1538996