### PR TITLE
The use of ems.address is deprecated

### DIFF
--- a/lib/VMwareWebService/miq_fault_tolerant_vim.rb
+++ b/lib/VMwareWebService/miq_fault_tolerant_vim.rb
@@ -9,7 +9,7 @@ class MiqFaultTolerantVim
 
     @erec     = options[:ems]
     auth_type = options[:auth_type] || :ws
-    ip        = options[:ip] || @erec.address
+    ip        = options[:ip] || @erec.hostname
     user      = options[:user] || @erec.authentication_userid(auth_type)
     pass      = options[:pass] || @erec.authentication_password(auth_type)
     @ems      = [ip, user, pass]


### PR DESCRIPTION
Switch to ems.hostname instead.