### PR TITLE
Increase the DRb::DRbServer.load_limit size from 50 to 100 MiB

### DIFF
--- a/lib/VMwareWebService/MiqVimBroker.rb
+++ b/lib/VMwareWebService/MiqVimBroker.rb
@@ -20,7 +20,7 @@ class MiqVimBroker
   attr_reader :shuttingDown
 
   MB = 1048576
-  DRb::DRbServer.default_load_limit(50 * MB)
+  DRb::DRbServer.default_load_limit(100 * MB)
 
   @@preLoad   = false
   @@debugUpdates  = false


### PR DESCRIPTION
Incrase the DRb::DRbServer.load_limit to 100MiB to handler larger vSphere inventories.

https://bugzilla.redhat.com/show_bug.cgi?id=1573588