### PR TITLE
Add VirtualMachine config.uuid to VimPropMaps

### DIFF
--- a/lib/VMwareWebService/VimPropMaps.rb
+++ b/lib/VMwareWebService/VimPropMaps.rb
@@ -184,6 +184,7 @@ module VimPropMaps
         "config.hotPlugMemoryIncrementSize",
         "config.hotPlugMemoryLimit",
         "config.memoryHotAddEnabled",
+        "config.uuid",
         "config.version",
         "datastore",
         "guest.net",


### PR DESCRIPTION
Collect config.uuid in addition to summary.config.uuid for cases when
the later is null.

https://bugzilla.redhat.com/show_bug.cgi?id=1569090