### PR TITLE
Bump rbvmomi version to 1.13.0

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "handsoap",             "~>0.2.5"
   spec.add_dependency "httpclient",           "~>2.8.0"
   spec.add_dependency "more_core_extensions", "~>3.2"
-  spec.add_dependency "rbvmomi",              "~>1.12.0"
+  spec.add_dependency "rbvmomi",              "~>1.13.0"
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'


### PR DESCRIPTION
Pull in https://github.com/vmware/rbvmomi/pull/138 to fix issues parsing
host virtual switch and portgroups.