### PR TITLE
Add MiqVimVm#renameVM method

### DIFF
--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -209,6 +209,14 @@ class MiqVimVm
     waitForTask(taskMor)
   end
 
+  def renameVM(newName)
+    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: calling rename_Task, vm=<#{@vmMor.inspect}>, newName=<#{newName}>" if $vim_log
+    task_mor = @invObj.rename_Task(@vmMor, newName)
+    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: returned from rename_Task" if $vim_log
+    $vim_log.debug "MiqVimVm::renameVM: taskMor = #{task_mor}" if $vim_log
+    waitForTask(task_mor)
+  end
+
   def relocateVM(host, pool = nil, datastore = nil, disk_move_type = nil, transform = nil, priority = "defaultPriority", disk = nil)
     pmor  = (pool.kind_of?(Hash) ? pool['MOR'] : pool)    if pool
     hmor  = (host.kind_of?(Hash) ? host['MOR'] : host)    if host

--- a/lib/VMwareWebService/VimService.rb
+++ b/lib/VMwareWebService/VimService.rb
@@ -838,6 +838,16 @@ class VimService < Handsoap::Service
     (parse_response(response, 'RemoveSnapshot_TaskResponse')['returnval'])
   end
 
+  def rename_Task(vmMor, newName)
+    response = invoke("n1:Rename_Task") do |message|
+      message.add("n1:_this", vmMor) do |i|
+        i.set_attr("type", vmMor.vimType)
+      end
+      message.add("n1:newName", newName)
+    end
+    parse_response(response, 'Rename_TaskResponse')['returnval']
+  end
+
   def renameSnapshot(snMor, name, desc)
     response = invoke("n1:RenameSnapshot") do |message|
       message.add "n1:_this", snMor do |i|


### PR DESCRIPTION
Add the ability to rename a VM from the MiqVimVm object.

VIM SDK definition: https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.ManagedEntity.html#rename

https://bugzilla.redhat.com/show_bug.cgi?id=1559184