### PR TITLE
Update Rubocop to add compatibility with new rules

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.52'
+  spec.add_development_dependency 'rubocop', '~> 0.53'
   spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
At [version`0.53.0`](https://github.com/bbatsov/rubocop/blob/3c3e315b84df45845440a25cbd71a5b99214b21d/CHANGELOG.md#0530-2018-03-05), the `TrailingCommaInLiteral` rule at Rubocop has been split into`TrailingCommaInHashLiteral` and `TrailingCommaInArrayLiteral` and no longer exists. The current version definition for Rubocop allow us to use the version `0.52` or superior, but it is not possible to have both versions by having that options in your `rubocop.yml` file.

In order to use the new updated rules, this PR updates the current rubocop version to `0.53`.

Should be merged with:
- https://github.com/ManageIQ/guides/pull/303