### PR TITLE
[WIP] Use latest handsoap version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gemspec
 
 gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 gem "manageiq-password", ">0", :require => false, :git => "https://github.com/ManageIQ/manageiq-password.git", :branch => "master"
-gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"

--- a/lib/VMwareWebService/VimService.rb
+++ b/lib/VMwareWebService/VimService.rb
@@ -5,7 +5,7 @@ require 'VMwareWebService/VimTypes'
 class VimService < Handsoap::Service
   attr_reader :sic, :about, :apiVersion, :isVirtualCenter, :v20, :v2, :v4, :serviceInstanceMor, :session_cookie
 
-  Handsoap.http_driver = :HTTPClient
+  Handsoap.http_driver = :httpclient
 
   def initialize(ep)
     super

--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport",        ">= 5.0", "< 5.2"
   spec.add_dependency "ffi",                  "~>1.9.3"
   spec.add_dependency "ffi-vix_disk_lib",     "~>1.0.4"  # used by VixDiskLib
-  spec.add_dependency "handsoap",             "~>0.2.5"
+  spec.add_dependency "handsoap",             "~>1.4.0"
   spec.add_dependency "httpclient",           "~>2.8.0"
   spec.add_dependency "more_core_extensions", "~>3.2"
   spec.add_dependency "rbvmomi",              "~>1.13.0"


### PR DESCRIPTION
Attempts to get us on the latest version of handsoap instead of pointing at a specific (old) tag.

WIP for now as I'm getting ` undefined method 'on_http_client_init'`, which I don't see defined anywhere.