### PR TITLE
Update ffi-vix_disk_lib to 1.0.5

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport",        ">= 5.0", "< 5.2"
   spec.add_dependency "ffi",                  "~>1.9.3"
-  spec.add_dependency "ffi-vix_disk_lib",     "~>1.0.4"  # used by VixDiskLib
+  spec.add_dependency "ffi-vix_disk_lib",     "~>1.0.5"  # used by VixDiskLib
   spec.add_dependency "handsoap",             "~>0.2.5"
   spec.add_dependency "httpclient",           "~>2.8.0"
   spec.add_dependency "more_core_extensions", "~>3.2"


### PR DESCRIPTION
ffi-vix_disk_lib 1.0.5, implemented via https://github.com/ManageIQ/ffi-vix_disk_lib/pull/13 
adds support for VmWare vddk 6.7.

@roliveri @agrare please review and merge (although I believe @agrare is indisposed for some number of days at the moment)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651702