### PR TITLE
Add broker support for VMware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea

--- a/lib/VMwareWebService/MiqPbmInventory.rb
+++ b/lib/VMwareWebService/MiqPbmInventory.rb
@@ -8,6 +8,7 @@ module MiqPbmInventory
       @pbm_svc = PbmService.new(vim) if apiVersion >= '5.5' && isVirtualCenter
     rescue => err
       $vim_log.warn("MiqPbmInventory: Failed to connect to SPBM endpoint: #{err}")
+      raise err.to_s
     end
   end
 

--- a/lib/VMwareWebService/MiqVim.rb
+++ b/lib/VMwareWebService/MiqVim.rb
@@ -18,9 +18,13 @@ class MiqVim < MiqVimInventory
   include MiqVimVdlConnectionMod
   include MiqPbmInventory
 
-  def initialize(server, username, password, cacheScope = nil)
-    super
+  attr_reader :proxyHost, :proxyPort
 
+  def initialize(server, username, password, cacheScope = nil, proxyHost = nil, proxyPort =nil)
+    super(server, username, password, cacheScope)
+
+    @proxyHost = proxyHost
+    @proxyPort = proxyPort
     pbm_initialize(self)
   end
 

--- a/lib/VMwareWebService/MiqVimBroker.rb
+++ b/lib/VMwareWebService/MiqVimBroker.rb
@@ -418,9 +418,9 @@ class MiqVimBroker
     end
   end
 
-  def getMiqVim(server, username, password)
+  def getMiqVim(server, username, password, cacheScope = nil, proxyHost = nil, proxyPort =nil)
     if @mode == :client
-      vim = @broker.getMiqVim(server, username, password)
+      vim = @broker.getMiqVim(server, username, password, cacheScope, proxyHost, proxyPort)
       vim.extend(MiqVimDump)
       vim.extend(MiqVimVdlConnectionMod)
       return(vim)

--- a/lib/VMwareWebService/miq_fault_tolerant_vim.rb
+++ b/lib/VMwareWebService/miq_fault_tolerant_vim.rb
@@ -7,12 +7,14 @@ class MiqFaultTolerantVim
     options = options.first if options.first.kind_of?(Hash)
     @vim = nil
 
-    @erec     = options[:ems]
-    auth_type = options[:auth_type] || :ws
-    ip        = options[:ip] || @erec.hostname
-    user      = options[:user] || @erec.authentication_userid(auth_type)
-    pass      = options[:pass] || @erec.authentication_password(auth_type)
-    @ems      = [ip, user, pass]
+    @erec      = options[:ems]
+    auth_type  = options[:auth_type] || :ws
+    ip         = options[:ip] || @erec.hostname
+    user       = options[:user] || @erec.authentication_userid(auth_type)
+    pass       = options[:pass] || @erec.authentication_password(auth_type)
+    proxy_host = options[:proxy_host]
+    proxy_port = options[:proxy_port]
+    @ems      = [ip, user, pass, nil, proxy_host, proxy_port]
 
     @use_broker = options.key?(:use_broker) ? options[:use_broker] : true
     if @use_broker


### PR DESCRIPTION
1.Throws an error, otherwise the connection will not appear on the foreground page even if it fails 2.Add broker support for VMware