### PR TITLE
The power of Positive Thinking™

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "handsoap",             "~>0.2.5"
   spec.add_dependency "httpclient",           "~>2.8.0"
   spec.add_dependency "more_core_extensions", "~>3.2"
-  spec.add_dependency "rbvmomi",              "~>1.13.0"
+  spec.add_dependency "rbvmomi",              "~>2.0.0"
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'


### PR DESCRIPTION
Upgrades rbvmomi to 2.0, for `optimist`s everyone.

Required because of https://github.com/vmware/rbvmomi/pull/145 and our recent switch to use `optimist` ourselves.

Thankfully, this change is less scary than it looks:

https://github.com/vmware/rbvmomi/compare/v1.13.0...v2.0.0