### PR TITLE
Collect the networkFolder under a Datacenter

### DIFF
--- a/lib/VMwareWebService/VimPropMaps.rb
+++ b/lib/VMwareWebService/VimPropMaps.rb
@@ -287,6 +287,7 @@ module VimPropMaps
         "datastoreFolder",
         "hostFolder",
         "name",
+        "networkFolder",
         "parent",
         "vmFolder"
       ]
@@ -475,6 +476,7 @@ module VimPropMaps
         "datastoreFolder",
         "hostFolder",
         "name",
+        "networkFolder",
         "parent",
         "vmFolder"
       ]


### PR DESCRIPTION
We were collecting the vmFolder, datastoreFolder, and hostFolder...all
except the networkFolder.  For consistency with streaming/graph refresh
we should collect the networkFolder.