### PR TITLE
Add Host OpaqueNetwork/Switch to VimPropMaps

### DIFF
--- a/lib/VMwareWebService/VimPropMaps.rb
+++ b/lib/VMwareWebService/VimPropMaps.rb
@@ -303,6 +303,8 @@ module VimPropMaps
         "config.network.dnsConfig.domainName",
         "config.network.dnsConfig.hostName",
         "config.network.ipRouteConfig.defaultGateway",
+        "config.network.opaqueNetwork",
+        "config.network.opaqueSwitch",
         "config.network.pnic",
         "config.network.portgroup",
         "config.network.vnic",


### PR DESCRIPTION
NSX networks are represented in the VIM sdk as a different
network/switch type.  Add the Opaque Network/Switch details to the
VimPropMaps for a HostSystem.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/397