### PR TITLE
Fix an issue connecting to a host directly

### DIFF
--- a/lib/VMwareWebService/MiqVimInventory.rb
+++ b/lib/VMwareWebService/MiqVimInventory.rb
@@ -41,6 +41,9 @@ class MiqVimInventory < MiqVimClientBase
       $vim_log.info "MiqVimInventory: unrecognized cache scope #{cacheScope}, using FullPropMap"
     end
 
+    # If we are connected to a virtual center then we can access additional properties
+    @propMap.merge!(PropMapVCenter) if isVirtualCenter && cacheScope != :cache_scope_event_monitor
+
     @propCol    = @sic.propertyCollector
     @rootFolder = @sic.rootFolder
     @objectSet  = objectSet

--- a/lib/VMwareWebService/VimPropMaps.rb
+++ b/lib/VMwareWebService/VimPropMaps.rb
@@ -91,15 +91,18 @@ module VimPropMaps
         'summary',
         'parent'
       ]
-    },
-    :LicenseManager              => {
+    }
+  }
+
+  PropMapVCenter = {
+    :LicenseManager   => {
       :baseName => "@licenseManagers",
       :keyPath  => nil,
       :props    => [
         'licenses'
       ]
     },
-    :ExtensionManager            => {
+    :ExtensionManager => {
       :baseName => "@extensionManagers",
       :keyPath  => nil,
       :props    => [


### PR DESCRIPTION
If we try to collect inventory from the host the collection fails because
hosts don't have the extensionManager or licenseManager.

Depends on: https://github.com/ManageIQ/vmware_web_service/pull/60