### PR TITLE
relocate_spec_disk_locator needs diskBackingInfo

### DIFF
--- a/lib/VMwareWebService/wsdl41/methods/VirtualMachineRelocateSpecDiskLocator.yml
+++ b/lib/VMwareWebService/wsdl41/methods/VirtualMachineRelocateSpecDiskLocator.yml
@@ -9,6 +9,8 @@ diskId:
   :type: :SOAP::SOAPInt
 datastore:
   :type: :ManagedObjectReference
+diskBackingInfo:
+  :type: :VirtualDeviceBackingInfo
 diskMoveType:
   :type: :SOAP::SOAPString
 profile:

--- a/lib/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
+++ b/lib/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
@@ -35435,6 +35435,9 @@
       ["datastore", "VimWs25::ManagedObjectReference"],
       ["diskMoveType", "SOAP::SOAPString", [0, 1]],
 
+      # diskBackingInfo added from VIM 5.0
+      ["diskBackingInfo", "VimWs25::VirtualDeviceBackingInfo", [0, 1]],
+
       # profile added from VIM 5.5
       ["profile", "VimWs25::VirtualMachineProfileSpec[]", [0, nil]]
     ]
@@ -78270,6 +78273,9 @@
       ["diskId", "SOAP::SOAPInt"],
       ["datastore", "VimWs25::ManagedObjectReference"],
       ["diskMoveType", "SOAP::SOAPString", [0, 1]],
+
+      # diskBackingInfo added from VIM 5.0
+      ["diskBackingInfo", "VimWs25::VirtualDeviceBackingInfo", [0, 1]],
 
       # profile added from VIM 5.5
       ["profile", "VimWs25::VirtualMachineProfileSpec[]", [0, nil]]


### PR DESCRIPTION
the relocate spec needs the backing info property so we can do Lazy Zeroed and Eager Zeroed thick provisioning


part of work for https://bugzilla.redhat.com/show_bug.cgi?id=1633867 


Related to https://github.com/ManageIQ/manageiq-providers-vmware/pull/413 and 
https://github.com/ManageIQ/manageiq-providers-vmware/pull/385