### PR TITLE
Drop ruby 2.3 and add ruby 2.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
-  - 2.4.2
+  - 2.4.6
+  - 2.5.3
 before_install: gem install bundler -v 1.14.4
 after_script: bundle exec codeclimate-test-reporter
 notifications:

--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A ruby interface to Vmware Web Services SDK"
   spec.licenses    = ["Apache-2.0"]
 
+  spec.required_ruby_version = "> 2.4"
   spec.files = Dir["{app,config,lib}/**/*"]
 
   spec.add_dependency "activesupport",        ">= 5.0", "< 5.3"


### PR DESCRIPTION
manageiq-gems-pending dropped support for 2.3 here https://github.com/ManageIQ/manageiq-gems-pending/pull/440

Ruby 2.3 was last used on gaprindashvilli which uses vmware_web_service 0.3.3 and this is on 0.4.z