### PR TITLE
[WIP] Remove dependency on gems-pending

### DIFF
--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -1,5 +1,4 @@
 require 'sync'
-require 'util/miq-extensions'  # Required patch to open-uri for get_file_content
 
 class MiqVimDataStore
   attr_reader :accessible, :multipleHostAccess, :name, :dsType, :url, :freeBytes, :capacityBytes, :uncommitted, :invObj


### PR DESCRIPTION
Remove the gems-pending dependency which was there to pull in the
util/extensions/miq-openuri extension.  This extension was deleted a
while ago by https://github.com/ManageIQ/manageiq-gems-pending/commit/37a63ac4555fc92fe7d8144c92c9f96ba0d2c47c

Tested VM smartstate of a VM with a snapshot (which is the only caller
of MiqVimDataStore#get_file_data) and confirmed that it works correctly
and returns the .vmsd file content.