### PR TITLE
Correct broker_timeout error class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 # Modified gems (forked on github)
 
 gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
+gem "handsoap", "=0.2.5.5", :require => false, :source => "http://rubygems.manageiq.org"

--- a/lib/VMwareWebService/broker_timeout.rb
+++ b/lib/VMwareWebService/broker_timeout.rb
@@ -36,7 +36,7 @@
 module Timeout
   def timeout(sec, klass = nil)   #:yield: +sec+
     return yield(sec) if sec.nil? or sec.zero?
-    exception = klass || Class.new(ExitException)
+    exception = klass || Class.new(Timeout::Error)
     state_lock = Mutex.new
     state = :sleeping
 

--- a/spec/VMwareWebService/broker_timeout_spec.rb
+++ b/spec/VMwareWebService/broker_timeout_spec.rb
@@ -1,0 +1,10 @@
+require 'timeout'
+require 'VMwareWebService/broker_timeout'
+
+describe Timeout do
+  describe ".timeout" do
+    it "doesn't fail when called without an error class" do
+      Timeout.timeout(1) { }
+    end
+  end
+end


### PR DESCRIPTION
Replace `ExitException` with `Timeout::Error`
`ExitException` was removed in ruby 2.2