### PR TITLE
Don't ignore SIGTERM

### DIFF
--- a/lib/VMwareWebService/MiqVimCoreUpdater.rb
+++ b/lib/VMwareWebService/MiqVimCoreUpdater.rb
@@ -61,8 +61,6 @@ class MiqVimCoreUpdater < MiqVimClientBase
 
     $vim_log.debug "#{log_prefix}: debugUpdates = #{@debugUpdates}"
 
-    trap(:TERM) { $vim_log.info "#{log_prefix}: ignoring SIGTERM" }
-
     begin
       @umPropCol     = @sic.propertyCollector
       @filterSpecRef = createFilter(@umPropCol, @updateSpec, "true")

--- a/lib/VMwareWebService/MiqVimEventMonitor.rb
+++ b/lib/VMwareWebService/MiqVimEventMonitor.rb
@@ -20,8 +20,6 @@ class MiqVimEventMonitor < MiqVimInventory
   def monitorEvents
     raise "monitorEvents: no block given" unless block_given?
 
-    trap(:TERM) { $vim_log.info "monitorEvents: ignoring SIGTERM" }
-
     eventHistoryCollector = createCollectorForEvents(@sic.eventManager, @eventFilterSpec)
     setCollectorPageSize(eventHistoryCollector, @pgSize)
 

--- a/lib/VMwareWebService/MiqVimUpdate.rb
+++ b/lib/VMwareWebService/MiqVimUpdate.rb
@@ -99,8 +99,6 @@ module MiqVimUpdate
 
     $vim_log.debug "#{log_prefix}: debugUpdates = #{@debugUpdates}"
 
-    trap(:TERM) { $vim_log.info "#{log_prefix}: ignoring SIGTERM" }
-
     begin
       @umPropCol     = @sic.propertyCollector
       @filterSpecRef = createFilter(@umPropCol, @updateSpec, "true")


### PR DESCRIPTION
Not sure why these were here, but we are now using SIGTERM to
cleanly shutdown workers. These handlers were causing the vmware
event catcher to fail to come down cleanly on server stop.

Fixes https://github.com/ManageIQ/manageiq/issues/19694