### PR TITLE
Allow running the monitorUpdates thread in MiqVim

### DIFF
--- a/lib/VMwareWebService/DMiqVim.rb
+++ b/lib/VMwareWebService/DMiqVim.rb
@@ -32,7 +32,7 @@ class DMiqVim < MiqVim
   # @param maxWait [Integer] How many seconds to wait before breaking out of WaitForUpdates (default: 60)
   # @param maxObjects [Integer] How many objects to return from each WaitForUpdates page (default: 250)
   def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil, maxWait = 60, maxObjects = 250)
-    super(server, username, password, cacheScope, true, preLoad, debugUpdates, notifyMethod, maxWait, maxObjects)
+    super(server, username, password, cacheScope, monitor_updates = true, preLoad, debugUpdates, notifyMethod, maxWait, maxObjects)
 
     @broker                 = broker
     @connectionShuttingDown = false

--- a/lib/VMwareWebService/DMiqVim.rb
+++ b/lib/VMwareWebService/DMiqVim.rb
@@ -21,6 +21,16 @@ class DMiqVim < MiqVim
   include DRb::DRbUndumped
   include DMiqVimSync
 
+  # @param server [String] DNS name or IP address of the vCenter Server 
+  # @param username [String] Username to connect to the vCenter Server
+  # @param password [String] Password to connect to the vCenter Server
+  # @param broker [MiqVimBroker] Instance of the broker worker this connection belongs to
+  # @param preLoad [Bool] Should the cache be built before returning the connection (default: false)
+  # @param debugUpdates [Bool] Should we print debug info for each update (default: false)
+  # @param notifyMethod [Method] A optional method to call for each update (default: nil)
+  # @param cacheScope [Symbol] A pre-defined set of properties to cache (default: nil)
+  # @param maxWait [Integer] How many seconds to wait before breaking out of WaitForUpdates (default: 60)
+  # @param maxObjects [Integer] How many objects to return from each WaitForUpdates page (default: 250)
   def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil, maxWait = 60, maxObjects = 250)
     super(server, username, password, cacheScope, true, preLoad, debugUpdates, notifyMethod, maxWait, maxObjects)
 

--- a/lib/VMwareWebService/DMiqVim.rb
+++ b/lib/VMwareWebService/DMiqVim.rb
@@ -1,5 +1,4 @@
 require 'VMwareWebService/MiqVim'
-require 'VMwareWebService/MiqVimUpdate'
 require 'VMwareWebService/DMiqVimSync'
 
 #
@@ -20,66 +19,14 @@ class DMiqVim < MiqVim
   alias_method :conditionalCopy, :deepClone
 
   include DRb::DRbUndumped
-  include MiqVimUpdate
   include DMiqVimSync
 
-  attr_reader :updateThread
-
   def initialize(server, username, password, broker, preLoad = false, debugUpdates = false, notifyMethod = nil, cacheScope = nil, maxWait = 60, maxObjects = 250)
-    super(server, username, password, cacheScope)
+    super(server, username, password, cacheScope, true, preLoad, debugUpdates, notifyMethod, maxWait, maxObjects)
 
-    log_prefix        = "DMiqVim.initialize (#{@connId})"
-    @broker         = broker
-    @updateMonitorReady   = false
-    @error          = nil
-    @notifyMethod     = notifyMethod
+    @broker                 = broker
     @connectionShuttingDown = false
-    @connectionRemoved    = false
-    @debugUpdates     = debugUpdates
-    @maxWait          = maxWait
-    @maxObjects       = maxObjects
-
-    checkForOrphanedMonitors
-    $vim_log.info "#{log_prefix}: starting update monitor thread" if $vim_log
-    @updateThread = Thread.new { monitor(preLoad) }
-    @updateThread[:vim_connection_id] = connId
-    $vim_log.info "#{log_prefix}: waiting for update monitor to become ready" if $vim_log
-    until @updateMonitorReady
-      raise @error unless @error.nil?
-      break unless @updateThread.alive?
-      Thread.pass
-    end
-    $vim_log.info "#{log_prefix}: update monitor ready" if $vim_log
-  end
-
-  # VC sometimes throws: Handsoap::Fault { :code => 'ServerFaultCode', :reason => 'The session is not authenticated.' }
-  # Handle this condition by reconnecting and monitoring again
-  # See http://communities.vmware.com/thread/190531
-  def handleSessionNotAuthenticated(err)
-    return false unless err.respond_to?(:reason) && err.reason == 'The session is not authenticated.'
-
-    log_prefix = "DMiqVim.handleSessionNotAuthenticated (#{@connId})"
-    $vim_log.error "#{log_prefix}: Reconnecting Session because '#{err.reason}'" if $vim_log
-    $vim_log.info "#{log_prefix}: Session(server=#{server}, username=#{username}) isAlive? => #{self.isAlive?.inspect}" if $vim_log
-
-    begin
-      $vim_log.info  "#{log_prefix}: Disconnecting Session" if $vim_log
-      serverPrivateDisconnect
-      $vim_log.info  "#{log_prefix}: Disconnecting Session...Complete" if $vim_log
-    rescue => disconnect_err
-      $vim_log.error "#{log_prefix}: Disconnecting Session...Error #{disconnect_err}" if $vim_log
-    end
-
-    begin
-      $vim_log.info  "#{log_prefix}: Connecting Session" if $vim_log
-      serverPrivateConnect
-      $vim_log.info  "#{log_prefix}: Connecting Session...Complete" if $vim_log
-    rescue => connect_err
-      $vim_log.error "#{log_prefix}: Connecting Session...Error #{connect_err}" if $vim_log
-      @error = err
-    end
-
-    @error.nil?
+    @connectionRemoved      = false
   end
 
   def monitor(preLoad)
@@ -116,29 +63,8 @@ class DMiqVim < MiqVim
     log_prefix = "DMiqVim.shutdownConnection (#{@connId})"
     $vim_log.info "#{log_prefix}: for address=<#{@server}>, username=<#{@username}>...Starting" if $vim_log
     @connectionShuttingDown = true
-    stopUpdateMonitor
-    begin
-      if @updateThread != Thread.current && @updateThread.alive?
-        $vim_log.info "#{log_prefix}: waiting for Update Monitor Thread...Starting" if $vim_log
-        @updateThread.join
-        $vim_log.info "#{log_prefix}: waiting for Update Monitor Thread...Complete" if $vim_log
-      end
-    rescue => err
-    end
     serverPrivateDisconnect if self.isAlive?
     $vim_log.info "#{log_prefix}: for address=<#{@server}>, username=<#{@username}>...Complete" if $vim_log
-  end
-
-  def checkForOrphanedMonitors
-    log_prefix = "DMiqVim.checkForOrphanedMonitors (#{@connId})"
-    $vim_log.debug "#{log_prefix}: called..."
-    Thread.list.each do |thr|
-      next unless thr[:vim_connection_id] == connId
-      $vim_log.error "#{log_prefix}: Terminating orphaned update monitor <#{thr.object_id}>"
-      thr.raise "Orphaned update monitor (#{@connId}) <#{thr.object_id}>, terminated by <#{Thread.current.object_id}>"
-      thr.wakeup
-    end
-    $vim_log.debug "#{log_prefix}: done."
   end
 
   def connectionRemoved?

--- a/lib/VMwareWebService/MiqVim.rb
+++ b/lib/VMwareWebService/MiqVim.rb
@@ -22,6 +22,16 @@ class MiqVim < MiqVimInventory
 
   attr_reader :updateThread, :monitor_updates
 
+  # @param server [String] DNS name or IP address of the vCenter Server 
+  # @param username [String] Username to connect to the vCenter Server
+  # @param password [String] Password to connect to the vCenter Server
+  # @param cacheScope [Symbol] A pre-defined set of properties to cache (default: nil)
+  # @param monitor_updates [Bool] Should a thread be started to monitor updates (default: false)
+  # @param preLoad [Bool] Should the cache be built before returning the connection (default: false)
+  # @param debugUpdates [Bool] Should we print debug info for each update (default: false)
+  # @param notifyMethod [Method] A optional method to call for each update (default: nil)
+  # @param maxWait [Integer] How many seconds to wait before breaking out of WaitForUpdates (default: 60)
+  # @param maxObjects [Integer] How many objects to return from each WaitForUpdates page (default: 250)
   def initialize(server, username, password, cacheScope = nil, monitor_updates = false, preLoad = false, debugUpdates = false, notifyMethod = nil, maxWait = 60, maxObjects = 250)
     super(server, username, password, cacheScope)
 


### PR DESCRIPTION
Now that some of the previous "broker" functionality is being run not
over DRb but from a shared session in a worker we need to be able to run
the monitor updates thread which keeps the inventory cache up to date
from MiqVim not just DMiqVim.

DMiqVim still has some extra logic specifically in error handling that
is specific to being run from within the broker so some of that is still
needed in DMiqVim but the bulk of it can move to MiqVim.