### PR TITLE
Undefine Hash#filter in VimHash, used by event catcher

### DIFF
--- a/lib/VMwareWebService/VimTypes.rb
+++ b/lib/VMwareWebService/VimTypes.rb
@@ -27,10 +27,11 @@ end
 class VimHash < Hash
   include VimType
 
-  undef_method(:id)   if method_defined?(:id)
-  undef_method(:type) if method_defined?(:type)
-  undef_method(:size) if method_defined?(:size)
-  undef_method(:key)  if method_defined?(:key)
+  undef_method(:id)     if method_defined?(:id)
+  undef_method(:type)   if method_defined?(:type)
+  undef_method(:size)   if method_defined?(:size)
+  undef_method(:key)    if method_defined?(:key)
+  undef_method(:filter) if method_defined?(:filter)
 
   def initialize(xsiType = nil, vimType = nil)
     self.xsiType = xsiType


### PR DESCRIPTION
Ruby 2.6 introduced a Hash#filter method which breaks the event catcher since it calls `#filter` on the PropertyFilterUpdate
https://github.com/ManageIQ/vmware_web_service/blob/master/lib/VMwareWebService/MiqVimEventMonitor.rb#L57