### PR TITLE
Prevent possible empty hash in vm["uuid"] field

### DIFF
--- a/lib/VMwareWebService/MiqVimEventMonitor.rb
+++ b/lib/VMwareWebService/MiqVimEventMonitor.rb
@@ -120,7 +120,7 @@ class MiqVimEventMonitor < MiqVimInventory
         next unless (vmObj = virtualMachinesByMor_locked[eventVmObj['vm']])
 
         eventVmObj['path'] = vmObj['summary']['config']['vmPathName']
-        eventVmObj['uuid'] = vmObj['summary']['config']['uuid']
+        eventVmObj['uuid'] = vmObj['summary']['config']['uuid'].presence
 
         removeVirtualMachine(eventVmObj['vm']) if event['eventType'] == 'VmRemovedEvent'
       end


### PR DESCRIPTION
It has been seen that the vm["uuid"] property can be {} which later
breaks database queries trying to cast VimHash to a string.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/420