### PR TITLE
Warning fixes

### DIFF
--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -290,8 +290,8 @@ class MiqVimDataStore
     if block_given?
       open(fileUrl, options) { |ret| yield(ret) }
     else
-      meta = {}; data = nil
-      open(fileUrl, options) { |ret| data = ret.read; meta = ret.meta }
+      data = nil
+      open(fileUrl, options) { |ret| data = ret.read }
       return data
     end
   end

--- a/lib/VMwareWebService/MiqVimUpdate.rb
+++ b/lib/VMwareWebService/MiqVimUpdate.rb
@@ -112,7 +112,7 @@ module MiqVimUpdate
         version = updates_version
         sleep @updateDelay if @updateDelay
       end # while @monitor
-    rescue SignalException => err
+    rescue SignalException
       # Ignore signals, except TERM
     rescue => herr
       if herr.respond_to?(:reason) && herr.reason == 'The task was canceled by a user.'

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -87,14 +87,6 @@ class MiqVimVm
     # @invObj.releaseObj(self)
   end
 
-  def vmMor
-    (@vmMor)
-  end
-
-  def vmh
-    (@vmh)
-  end
-
   #######################
   # Power state methods.
   #######################
@@ -317,23 +309,23 @@ class MiqVimVm
     return(@snapshotInfo) if @snapshotInfo && !refresh
 
     begin
-        @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
+      @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-        unless (ssp = @invObj.getMoProp_local(@vmMor, "snapshot"))
-          @snapshotInfo = nil
-          return(nil)
-        end
-
-        ssObj = ssp["snapshot"]
-        ssMorHash = {}
-        rsl = ssObj['rootSnapshotList']
-        rsl = [rsl] unless rsl.kind_of?(Array)
-        rsl.each { |rs| @invObj.snapshotFixup(rs, ssMorHash) }
-        ssObj['ssMorHash'] = ssMorHash
-        @snapshotInfo = ssObj
-      ensure
-        @cacheLock.sync_unlock if unlock
+      unless (ssp = @invObj.getMoProp_local(@vmMor, "snapshot"))
+        @snapshotInfo = nil
+        return(nil)
       end
+
+      ssObj = ssp["snapshot"]
+      ssMorHash = {}
+      rsl = ssObj['rootSnapshotList']
+      rsl = [rsl] unless rsl.kind_of?(Array)
+      rsl.each { |rs| @invObj.snapshotFixup(rs, ssMorHash) }
+      ssObj['ssMorHash'] = ssMorHash
+      @snapshotInfo = ssObj
+    ensure
+      @cacheLock.sync_unlock if unlock
+    end
 
     (@snapshotInfo)
   end # def snapshotInfo_locked
@@ -800,11 +792,11 @@ class MiqVimVm
               bck.writeThrough  = "false"
               bck.fileName    = backingFile
               begin
-                  dsn = @invObj.path2dsName(@dsPath)
-                  bck.datastore = @invObj.dsName2mo_local(dsn)
-                rescue
-                  bck.datastore = nil
-                end
+                dsn = @invObj.path2dsName(@dsPath)
+                bck.datastore = @invObj.dsName2mo_local(dsn)
+              rescue
+                bck.datastore = nil
+              end
             end
           end
         end
@@ -856,11 +848,11 @@ class MiqVimVm
               bck.writeThrough  = "false"
               bck.fileName    = backingFile
               begin
-                  dsn = @invObj.path2dsName(@dsPath)
-                  bck.datastore = @invObj.dsName2mo(dsn)
-                rescue
-                  bck.datastore = nil
-                end
+                dsn = @invObj.path2dsName(@dsPath)
+                bck.datastore = @invObj.dsName2mo(dsn)
+              rescue
+                bck.datastore = nil
+              end
             end unless deleteBacking
           end
         end
@@ -1037,24 +1029,24 @@ class MiqVimVm
     end
 
     begin
-        @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
+      @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-        alarmManager = @sic.alarmManager
-        #
-        # Add disabled if VM is running.
-        #
-        if poweredOff?
-          aSpec = @miqAlarmSpecEnabled
-        else
-          aSpec = @miqAlarmSpecDisabled
-        end
-        $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: calling createAlarm" if $vim_log
-        alarmMor = @invObj.createAlarm(alarmManager, @vmMor, aSpec)
-        $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: returned from createAlarm" if $vim_log
-        @miqAlarmMor = alarmMor
-      ensure
-        @cacheLock.sync_unlock if unlock
+      alarmManager = @sic.alarmManager
+      #
+      # Add disabled if VM is running.
+      #
+      if poweredOff?
+        aSpec = @miqAlarmSpecEnabled
+      else
+        aSpec = @miqAlarmSpecDisabled
       end
+      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: calling createAlarm" if $vim_log
+      alarmMor = @invObj.createAlarm(alarmManager, @vmMor, aSpec)
+      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: returned from createAlarm" if $vim_log
+      @miqAlarmMor = alarmMor
+    ensure
+      @cacheLock.sync_unlock if unlock
+    end
 
     (alarmMor)
   end # def addMiqAlarm_locked


### PR DESCRIPTION
This fixes a series of warnings that you'll see when running the smartstate specs. Specifically:
```
lib/VMwareWebService/MiqVimVm.rb:336: warning: mismatched indentations at 'end' with 'begin' at 319
lib/VMwareWebService/MiqVimVm.rb:807: warning: mismatched indentations at 'end' with 'begin' at 802
lib/VMwareWebService/MiqVimVm.rb:863: warning: mismatched indentations at 'end' with 'begin' at 858
lib/VMwareWebService/MiqVimVm.rb:1057: warning: mismatched indentations at 'end' with 'begin' at 1039
lib/VMwareWebService/MiqVimVm.rb:90: warning: method redefined; discarding old vmMor
lib/VMwareWebService/MiqVimVm.rb:94: warning: method redefined; discarding old vmh
lib/VMwareWebService/MiqVimDataStore.rb:293: warning: assigned but unused variable - meta
lib/VMwareWebService/MiqVimUpdate.rb:115: warning: assigned but unused variable - err
```
In short, some formatting (alignment) updates, a couple of redundant reader methods removed (`attr_reader` was already declared) and one unused variable removed (`meta`).