### PR TITLE
Fix code injection vulnerability in activesupport

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "> 2.4"
   spec.files = Dir["{app,config,lib}/**/*"]
 
-  spec.add_dependency "activesupport",        ">= 5.0", "< 5.3"
+  spec.add_dependency "activesupport",        "~> 5.2.4", ">= 5.2.4.3"
   spec.add_dependency "ffi-vix_disk_lib",     "~>1.1"
   spec.add_dependency "handsoap",             "~>0.2.5"
   spec.add_dependency "httpclient",           "~>2.8.0"


### PR DESCRIPTION
Fixed in ActiveSupport 5.2.4.3

https://hakiri.io/github/ManageIQ/vmware_web_service/master/7436ee8637b89780c4b66debba4ca63c16c8df94/warnings?name=Code+Injection

Ivanchuk uses vmware_web_service v0.4* so we wont break the ivanchuk branch with this change and jansa already uses rails 5.2.4.3