### PR TITLE
Ensure snapshot createTime format matches refresh

### DIFF
--- a/lib/VMwareWebService/MiqVimInventory.rb
+++ b/lib/VMwareWebService/MiqVimInventory.rb
@@ -366,7 +366,12 @@ class MiqVimInventory < MiqVimClientBase
     #
     # Hash snapshot info by create time.
     #
-    ssMorHash[ssObj['createTime']] = ssObj
+    # VMware API strips trailing '0's from the fractional seconds
+    # which causes the string to not match what .iso8601(6) returns
+    #
+    # Example 12:12:59.123Z instead of 12:12:59.123000Z
+    create_time = Time.parse(ssObj['createTime']).iso8601(6)
+    ssMorHash[create_time] = ssObj
 
     #
     # Ensure childSnapshotList is always present and always an array,


### PR DESCRIPTION
The createTime format returned by the vCenter API is iso8601 but doesn't pad 0s out to the decimal precision like Time#iso8601 does.

This means that if there is a trailing 0 for the createTime getSnapMor won't find the snapshot and snap deletes and reverts will fail.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/631