### PR TITLE
Fix Array.wrap failure after gems-pending update

### DIFF
--- a/lib/VMwareWebService/MiqVimCustomizationSpecManager.rb
+++ b/lib/VMwareWebService/MiqVimCustomizationSpecManager.rb
@@ -34,7 +34,7 @@ class MiqVimCustomizationSpecManager
     specs = info
     return [] if specs.nil?
 
-    specs = Array.wrap(specs.dup)
+    specs = Array(specs.dup)
     specs.each { |s| s['spec'] = getCustomizationSpec(s['name'].to_s).spec }
     specs
   end

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -909,7 +909,7 @@ class MiqVimVm
     scsi_controllers.sort_by { |s| s["key"].to_i }.each do |scsi_controller|
       # Skip if all controller units are populated
       # Bus has 16 units, controller takes up 1 unit itself
-      device = Array.wrap(scsi_controller["device"])
+      device = Array(scsi_controller["device"])
       next if device.count >= MAX_SCSI_DEVICES
 
       # We've found the lowest scsi controller with an available unit


### PR DESCRIPTION
When gems-pending removed to_miq_a we also lost the implicit `require 'active_support/core_ext/array/wrap'`

https://github.com/ManageIQ/manageiq-gems-pending/pull/489