### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
dropping `sudo:false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Also kind of wonder if we can update the ruby versions since this looks a little out of date but maybe that's a separate pr.