### PR TITLE
[WIP] Restart monitorUpdates while session is alive

### DIFF
--- a/lib/VMwareWebService/MiqVim.rb
+++ b/lib/VMwareWebService/MiqVim.rb
@@ -283,12 +283,15 @@ class MiqVim < MiqVimInventory
 
   def monitor(preLoad)
     log_prefix = "MiqVim.monitor (#{@connId})"
-    begin
-      monitorUpdates(preLoad)
-    rescue Exception => err
-      $vim_log.info "#{log_prefix}: returned from monitorUpdates via #{err.class} exception" if $vim_log
-      @error = err
-    end
+
+    monitorUpdates(preLoad)
+  rescue Exception => err
+    $vim_log.info "#{log_prefix}: returned from monitorUpdates via #{err.class} exception" if $vim_log
+    @error = err
+
+    # If the monitorUpdates loop raised an exception but the underlying connection
+    # is still alive then simply restart the monitorUpdates loop
+    retry if isAlive?
   end
 
   def shutdown_monitor_updates_thread


### PR DESCRIPTION
If the monitorUpdates loop throws an exception it was never getting restarted which led to new vms not being in the cache and causing cache lookup failures.

If the session isAlive? but the loop exited we should restart it.

Here the monitorUpdates loop fails with a SocketError, but the session was still valid and continued to be operational

```
HandSoap Request  [47407605005980]: length: [483], URI: [https://visvc6-sdk01/sdk], Content-Type: [text/xml;charset=UTF-8], SOAPAction: [WaitForUpdatesEx]
******* SocketError
getaddrinfo: Name or service not known (visvc6-sdk01:443)
/gems/httpclient-2.8.3/lib/httpclient/session.rb:625:in `rescue in create_socket'
/gems/httpclient-2.8.3/lib/httpclient/session.rb:607:in `create_socket'
/gems/httpclient-2.8.3/lib/httpclient/ssl_socket.rb:21:in `create_socket'
/gems/httpclient-2.8.3/lib/httpclient/session.rb:752:in `block in connect'
/usr/share/ruby/timeout.rb:93:in `block in timeout'
/usr/share/ruby/timeout.rb:103:in `timeout'
/gems/httpclient-2.8.3/lib/httpclient/session.rb:748:in `connect'
/gems/httpclient-2.8.3/lib/httpclient/session.rb:511:in `query'
/gems/httpclient-2.8.3/lib/httpclient/session.rb:177:in `query'
/gems/httpclient-2.8.3/lib/httpclient.rb:1242:in `do_get_block'
/gems/httpclient-2.8.3/lib/httpclient.rb:1019:in `block in do_request'
/gems/httpclient-2.8.3/lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
/gems/httpclient-2.8.3/lib/httpclient.rb:1014:in `do_request'
/gems/httpclient-2.8.3/lib/httpclient.rb:856:in `request'
/gems/httpclient-2.8.3/lib/httpclient.rb:765:in `post'
/gems/handsoap-0.2.5.5/lib/handsoap/service.rb:299:in `dispatch'
/gems/handsoap-0.2.5.5/lib/handsoap/service.rb:211:in `invoke'
/gems/vmware_web_service-2.0.2/lib/VMwareWebService/VimService.rb:1217:in `waitForUpdatesEx'
/gems/vmware_web_service-2.0.2/lib/VMwareWebService/MiqVimUpdate.rb:62:in `monitorUpdatesSince'
/gems/vmware_web_service-2.0.2/lib/VMwareWebService/MiqVimUpdate.rb:110:in `monitorUpdates'
/gems/vmware_web_service-2.0.2/lib/VMwareWebService/MiqVim.rb:287:in `monitor'
/gems/vmware_web_service-2.0.2/lib/VMwareWebService/MiqVim.rb:261:in `block in start_monitor_updates_thread'
MiqVimInventory(visvc6-sdk01, root).getMoProp_local: calling retrieveProperties(SessionManager)
HandSoap Request  [47407607329400]: length: [844], URI: [https://visvc6-sdk01/sdk], Content-Type: [text/xml;charset=UTF-8], SOAPAction: [RetrievePropertiesEx]
HandSoap Response [47407607329400]: length: [1028], HTTP-Status: [200], Content-Type: [text/xml; charset=utf-8]
MiqVimInventory(visvc6-sdk01, root).getMoProp_local: return from retrieveProperties(SessionManager)
MiqVimUpdate.monitorUpdates (visvc6-sdk01_root): calling destroyPropertyFilter...Starting
HandSoap Request  [47407607470180]: length: [420], URI: [https://visvc6-sdk01/sdk], Content-Type: [text/xml;charset=UTF-8], SOAPAction: [DestroyPropertyFilter]
HandSoap Response [47407607470180]: length: [408], HTTP-Status: [200], Content-Type: [text/xml; charset=utf-8]
MiqVimUpdate.monitorUpdates (visvc6-sdk01_root): calling destroyPropertyFilter...Complete
```