### PR TITLE
Rails 6 doesn't support ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 cache: bundler
 language: ruby
 rvm:
-  - 2.4.6
-  - 2.5.3
+  - 2.5.8
+  - 2.6.6
 before_install: gem install bundler -v 1.14.4
 after_script: bundle exec codeclimate-test-reporter
 notifications:

--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A ruby interface to Vmware Web Services SDK"
   spec.licenses    = ["Apache-2.0"]
 
-  spec.required_ruby_version = "> 2.4"
+  spec.required_ruby_version = ">= 2.5.0"
   spec.files = Dir["{app,config,lib}/**/*"]
 
   spec.add_dependency "activesupport",        ">= 5.2.4.3", "< 6.1"


### PR DESCRIPTION
Travis is failing on ruby 2.4: https://travis-ci.com/github/ManageIQ/vmware_web_service/jobs/471939906

```
Bundler could not find compatible versions for gem "ruby":

  In Gemfile:
    ruby

    manageiq-gems-pending (> 0) was resolved to 0.1.0, which depends on
      activesupport (~> 6.0) was resolved to 6.1.1, which depends on
        ruby (>= 2.5.0)

    vmware_web_service was resolved to 2.1.0, which depends on
      ruby (> 2.4)
```