### PR TITLE
Drop the manageiq-password dependency

### DIFF
--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codeclimate-test-reporter", '~> 1.0.0'
-  spec.add_development_dependency "manageiq-password"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",                     '~> 3.0'


### PR DESCRIPTION
https://github.com/ManageIQ/vmware_web_service/pull/104 removed the only usage of ManageIQ::Password so this gem can be dropped now from the gemspec