### PR TITLE
Use $stdout in VixDiskLibServer for logging

### DIFF
--- a/lib/VMwareWebService/VixDiskLib/VixDiskLibServer.rb
+++ b/lib/VMwareWebService/VixDiskLib/VixDiskLibServer.rb
@@ -11,9 +11,7 @@ require 'VMwareWebService/VixDiskLib/vdl_wrapper'
 class VixDiskLibError < RuntimeError
 end
 
-LOG_FILE    = ENV["LOG_FILE"]
-
-$vim_log = Logger.new LOG_FILE
+$vim_log = Logger.new $stdout
 
 class VDDKFactory
   include DRb::DRbUndumped

--- a/lib/VMwareWebService/VixDiskLib/vdl_wrapper.rb
+++ b/lib/VMwareWebService/VixDiskLib/vdl_wrapper.rb
@@ -4,9 +4,7 @@ require 'ffi-vix_disk_lib/api_wrapper'
 require 'VMwareWebService/VimTypes'
 require 'time'
 
-LOG_FILE    = ENV["LOG_FILE"]
-
-$vim_log = Logger.new LOG_FILE
+$vim_log = Logger.new $stdout
 
 VixDiskLibApi = FFI::VixDiskLib::ApiWrapper
 class VdlWrapper


### PR DESCRIPTION
When we spawn we're already setting `:out` to the file, so logging to stdout in the child process would have gone to the log file anyway.  In addition to this use the parent process's $stdout