### PR TITLE
Add a VMwareWebService.logger replacing global $vim_log from core

### DIFF
--- a/lib/VMwareWebService/MiqHostDatastoreSystem.rb
+++ b/lib/VMwareWebService/MiqHostDatastoreSystem.rb
@@ -1,4 +1,8 @@
+require 'VMwareWebService/logging'
+
 class MiqHostDatastoreSystem
+  include VMwareWebService::Logging
+
   attr_reader :invObj
 
   def initialize(dssMor, invObj)
@@ -44,7 +48,7 @@ class MiqHostDatastoreSystem
     localPath = dsh.info.nas.name
     type    = dsh.info.nas.type
 
-    $vim_log.info "MiqHostDatastoreSystem.addNasDatastoreByName: remoteHost = #{remoteHost}, remotePath = #{remotePath}, localPath = #{localPath}"
+    logger.info "MiqHostDatastoreSystem.addNasDatastoreByName: remoteHost = #{remoteHost}, remotePath = #{remotePath}, localPath = #{localPath}"
     createNasDatastore(remoteHost, remotePath, localPath, accessMode, type)
   end
 end # class MiqHostDatastoreSystem

--- a/lib/VMwareWebService/MiqVim.rb
+++ b/lib/VMwareWebService/MiqVim.rb
@@ -67,24 +67,24 @@ class MiqVim < MiqVimInventory
   end
 
   def getVimVm(path)
-    $vim_log.info "MiqVimMod.getVimVm: called"
+    logger.info "MiqVimMod.getVimVm: called"
     miqVimVm = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find VM: #{path}" unless (vmh = virtualMachines_locked[path])
       miqVimVm = MiqVimVm.new(self, conditionalCopy(vmh))
     end
-    $vim_log.info "MiqVimMod.getVimVm: returning object #{miqVimVm.object_id}"
+    logger.info "MiqVimMod.getVimVm: returning object #{miqVimVm.object_id}"
     (miqVimVm)
   end # def getVimVm
 
   def getVimVmByMor(vmMor)
-    $vim_log.info "MiqVimMod.getVimVmByMor: called"
+    logger.info "MiqVimMod.getVimVmByMor: called"
     miqVimVm = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find VM: #{vmMor}" unless (vmh = virtualMachinesByMor_locked[vmMor])
       miqVimVm = MiqVimVm.new(self, conditionalCopy(vmh))
     end
-    $vim_log.info "MiqVimMod.getVimVmByMor: returning object #{miqVimVm.object_id}"
+    logger.info "MiqVimMod.getVimVmByMor: returning object #{miqVimVm.object_id}"
     (miqVimVm)
   end # def getVimVmByMor
 
@@ -93,36 +93,36 @@ class MiqVim < MiqVimInventory
   # matches the criteria defined by the filter.
   #
   def getVimVmByFilter(filter)
-    $vim_log.info "MiqVimMod.getVimVmByFilter: called"
+    logger.info "MiqVimMod.getVimVmByFilter: called"
     miqVimVm = nil
     @cacheLock.synchronize(:SH) do
       vms = applyFilter(virtualMachinesByMor_locked.values, filter)
       raise MiqException::MiqVimResourceNotFound, "getVimVmByFilter: Could not find VM matching filter" if vms.empty?
       miqVimVm = MiqVimVm.new(self, conditionalCopy(vms[0]))
     end
-    $vim_log.info "MiqVimMod.getVimVmByFilter: returning object #{miqVimVm.object_id}"
+    logger.info "MiqVimMod.getVimVmByFilter: returning object #{miqVimVm.object_id}"
     (miqVimVm)
   end # def getVimVmByFilter
 
   def getVimHost(name)
-    $vim_log.info "MiqVimMod.getVimHost: called"
+    logger.info "MiqVimMod.getVimHost: called"
     miqVimHost = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find Host: #{name}" unless (hh = hostSystems_locked[name])
       miqVimHost = MiqVimHost.new(self, conditionalCopy(hh))
     end
-    $vim_log.info "MiqVimMod.getVimHost: returning object #{miqVimHost.object_id}"
+    logger.info "MiqVimMod.getVimHost: returning object #{miqVimHost.object_id}"
     (miqVimHost)
   end # def getVimHost
 
   def getVimHostByMor(hMor)
-    $vim_log.info "MiqVimMod.getVimHostByMor: called"
+    logger.info "MiqVimMod.getVimHostByMor: called"
     miqVimHost = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find Host: #{hMor}" unless (hh = hostSystemsByMor_locked[hMor])
       miqVimHost = MiqVimHost.new(self, conditionalCopy(hh))
     end
-    $vim_log.info "MiqVimMod.getVimHostByMor: returning object #{miqVimHost.object_id}"
+    logger.info "MiqVimMod.getVimHostByMor: returning object #{miqVimHost.object_id}"
     (miqVimHost)
   end # def getVimHostByMor
 
@@ -131,48 +131,48 @@ class MiqVim < MiqVimInventory
   # matches the criteria defined by the filter.
   #
   def getVimHostByFilter(filter)
-    $vim_log.info "MiqVimMod.getVimHostByFilter: called"
+    logger.info "MiqVimMod.getVimHostByFilter: called"
     miqVimHost = nil
     @cacheLock.synchronize(:SH) do
       ha = applyFilter(hostSystemsByMor_locked.values, filter)
       raise MiqException::MiqVimResourceNotFound, "getVimHostByFilter: Could not find Host matching filter" if ha.empty?
       miqVimHost = MiqVimHost.new(self, conditionalCopy(ha[0]))
     end
-    $vim_log.info "MiqVimMod.getVimHostByFilter: returning object #{miqVimHost.object_id}"
+    logger.info "MiqVimMod.getVimHostByFilter: returning object #{miqVimHost.object_id}"
     (miqVimHost)
   end # def getVimHostByFilter
 
   def getVimFolder(name)
-    $vim_log.info "MiqVimMod.getVimFolder: called"
+    logger.info "MiqVimMod.getVimFolder: called"
     miqVimFolder = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find Folder: #{name}" unless (fh = folders_locked[name])
       miqVimFolder = MiqVimFolder.new(self, conditionalCopy(fh))
     end
-    $vim_log.info "MiqVimMod.getVimFolder: returning object #{miqVimFolder.object_id}"
+    logger.info "MiqVimMod.getVimFolder: returning object #{miqVimFolder.object_id}"
     (miqVimFolder)
   end # def getVimFolder
 
   def getVimFolderByMor(fMor)
-    $vim_log.info "MiqVimMod.getVimFolderByMor: called"
+    logger.info "MiqVimMod.getVimFolderByMor: called"
     miqVimFolder = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find Folder: #{fMor}" unless (fh = foldersByMor_locked[fMor])
       miqVimFolder = MiqVimFolder.new(self, conditionalCopy(fh))
     end
-    $vim_log.info "MiqVimMod.getVimFolderByMor: returning object #{miqVimFolder.object_id}"
+    logger.info "MiqVimMod.getVimFolderByMor: returning object #{miqVimFolder.object_id}"
     (miqVimFolder)
   end # def getVimFolderByMor
 
   def getVimFolderByFilter(filter)
-    $vim_log.info "MiqVimMod.getVimFolderByFilter: called"
+    logger.info "MiqVimMod.getVimFolderByFilter: called"
     miqVimFolder = nil
     @cacheLock.synchronize(:SH) do
       folders = applyFilter(foldersByMor_locked.values, filter)
       raise MiqException::MiqVimResourceNotFound, "getVimFolderByFilter: Could not find folder matching filter" if folders.empty?
       miqVimFolder = MiqVimFolder.new(self, conditionalCopy(folders[0]))
     end
-    $vim_log.info "MiqVimMod.getVimFolderByFilter: returning object #{miqVimFolder.object_id}"
+    logger.info "MiqVimMod.getVimFolderByFilter: returning object #{miqVimFolder.object_id}"
     (miqVimFolder)
   end # def getVimFolderByFilter
 
@@ -180,36 +180,36 @@ class MiqVim < MiqVimInventory
   # Cluster
   #
   def getVimCluster(name)
-    $vim_log.info "MiqVimMod.getVimCluster: called"
+    logger.info "MiqVimMod.getVimCluster: called"
     miqVimCluster = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find Cluster: #{name}" unless (ch = clusterComputeResources_locked[name])
       miqVimCluster = MiqVimCluster.new(self, conditionalCopy(ch))
     end
-    $vim_log.info "MiqVimMod.getVimCluster: returning object #{miqVimCluster.object_id}"
+    logger.info "MiqVimMod.getVimCluster: returning object #{miqVimCluster.object_id}"
     (miqVimCluster)
   end # def getVimCluster
 
   def getVimClusterByMor(cMor)
-    $vim_log.info "MiqVimMod.getVimClusterByMor: called"
+    logger.info "MiqVimMod.getVimClusterByMor: called"
     miqVimCluster = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find Cluster: #{cMor}" unless (ch = clusterComputeResourcesByMor_locked[cMor])
       miqVimCluster = MiqVimCluster.new(self, conditionalCopy(ch))
     end
-    $vim_log.info "MiqVimMod.getVimClusterByMor: returning object #{miqVimCluster.object_id}"
+    logger.info "MiqVimMod.getVimClusterByMor: returning object #{miqVimCluster.object_id}"
     (miqVimCluster)
   end # def getVimClusterByMor
 
   def getVimClusterByFilter(filter)
-    $vim_log.info "MiqVimMod.getVimClusterByFilter: called"
+    logger.info "MiqVimMod.getVimClusterByFilter: called"
     miqVimCluster = nil
     @cacheLock.synchronize(:SH) do
       clusters = applyFilter(clusterComputeResourcesByMor_locked.values, filter)
       raise MiqException::MiqVimResourceNotFound, "getVimClusterByFilter: Could not find Cluster matching filter" if clusters.empty?
       miqVimCluster = MiqVimCluster.new(self, conditionalCopy(clusters[0]))
     end
-    $vim_log.info "MiqVimMod.getVimClusterByFilter: returning object #{miqVimCluster.object_id}"
+    logger.info "MiqVimMod.getVimClusterByFilter: returning object #{miqVimCluster.object_id}"
     (miqVimCluster)
   end # def getVimClusterByFilter
 
@@ -217,54 +217,54 @@ class MiqVim < MiqVimInventory
   # DataStore
   #
   def getVimDataStore(dsName)
-    $vim_log.info "MiqVimMod.getVimDataStore: called"
+    logger.info "MiqVimMod.getVimDataStore: called"
     miqVimDs = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find datastore: #{dsName}" unless (dsh = dataStores_locked[dsName])
       miqVimDs = MiqVimDataStore.new(self, conditionalCopy(dsh))
     end
-    $vim_log.info "MiqVimMod.getVimDataStore: returning object #{miqVimDs.object_id}"
+    logger.info "MiqVimMod.getVimDataStore: returning object #{miqVimDs.object_id}"
     (miqVimDs)
   end
 
   def getVimDataStoreByMor(dsMor)
-    $vim_log.info "MiqVimMod.getVimDataStoreByMor: called"
+    logger.info "MiqVimMod.getVimDataStoreByMor: called"
     miqVimDs = nil
     @cacheLock.synchronize(:SH) do
       raise MiqException::MiqVimResourceNotFound, "Could not find datastore: #{dsMor}" unless (dsh = dataStoresByMor_locked[dsMor])
       miqVimDs = MiqVimDataStore.new(self, conditionalCopy(dsh))
     end
-    $vim_log.info "MiqVimMod.getVimDataStoreByMor: returning object #{miqVimDs.object_id}"
+    logger.info "MiqVimMod.getVimDataStoreByMor: returning object #{miqVimDs.object_id}"
     (miqVimDs)
   end
 
   def getVimPerfHistory
     miqVimPh = MiqVimPerfHistory.new(self)
-    $vim_log.info "MiqVimMod.getVimPerfHistory: returning object #{miqVimPh.object_id}"
+    logger.info "MiqVimMod.getVimPerfHistory: returning object #{miqVimPh.object_id}"
     (miqVimPh)
   end
 
   def getVimEventHistory(eventFilterSpec = nil, pgSize = 20)
     miqVimEh = MiqVimEventHistoryCollector.new(self, eventFilterSpec, pgSize)
-    $vim_log.info "MiqVimMod.getVimEventHistory: returning object #{miqVimEh.object_id}"
+    logger.info "MiqVimMod.getVimEventHistory: returning object #{miqVimEh.object_id}"
     (miqVimEh)
   end
 
   def getMiqCustomFieldsManager
     miqVimCfm = MiqCustomFieldsManager.new(self)
-    $vim_log.info "MiqVimMod.getMiqCustomFieldsManager: returning object #{miqVimCfm.object_id}"
+    logger.info "MiqVimMod.getMiqCustomFieldsManager: returning object #{miqVimCfm.object_id}"
     (miqVimCfm)
   end
 
   def getVimAlarmManager
     miqVimAm = MiqVimAlarmManager.new(self)
-    $vim_log.info "MiqVimMod.getVimAlarmManager: returning object #{miqVimAm.object_id}"
+    logger.info "MiqVimMod.getVimAlarmManager: returning object #{miqVimAm.object_id}"
     (miqVimAm)
   end
 
   def getVimCustomizationSpecManager
     miqVimCsm = MiqVimCustomizationSpecManager.new(self)
-    $vim_log.info "MiqVimMod.getVimCustomizationSpecManager: returning object #{miqVimCsm.object_id}"
+    logger.info "MiqVimMod.getVimCustomizationSpecManager: returning object #{miqVimCsm.object_id}"
     (miqVimCsm)
   end
 
@@ -279,28 +279,28 @@ class MiqVim < MiqVimInventory
   def start_monitor_updates_thread(preLoad)
     checkForOrphanedMonitors
     log_prefix          = "MiqVim.initialize (#{@connId})"
-    $vim_log.info "#{log_prefix}: starting update monitor thread" if $vim_log
+    logger.info "#{log_prefix}: starting update monitor thread" if logger
     @updateThread = Thread.new { monitor(preLoad) }
     @updateThread[:vim_connection_id] = connId
-    $vim_log.info "#{log_prefix}: waiting for update monitor to become ready" if $vim_log
+    logger.info "#{log_prefix}: waiting for update monitor to become ready" if logger
     until @updateMonitorReady
       raise @error unless @error.nil?
       break unless @updateThread.alive?
       Thread.pass
     end
-    $vim_log.info "#{log_prefix}: update monitor ready" if $vim_log
+    logger.info "#{log_prefix}: update monitor ready" if logger
   end
 
   def checkForOrphanedMonitors
     log_prefix = "MiqVim.checkForOrphanedMonitors (#{@connId})"
-    $vim_log.debug "#{log_prefix}: called..."
+    logger.debug "#{log_prefix}: called..."
     Thread.list.each do |thr|
       next unless thr[:vim_connection_id] == connId
-      $vim_log.error "#{log_prefix}: Terminating orphaned update monitor <#{thr.object_id}>"
+      logger.error "#{log_prefix}: Terminating orphaned update monitor <#{thr.object_id}>"
       thr.raise "Orphaned update monitor (#{@connId}) <#{thr.object_id}>, terminated by <#{Thread.current.object_id}>"
       thr.wakeup
     end
-    $vim_log.debug "#{log_prefix}: done."
+    logger.debug "#{log_prefix}: done."
   end
 
   def monitor(preLoad)
@@ -308,7 +308,7 @@ class MiqVim < MiqVimInventory
     begin
       monitorUpdates(preLoad)
     rescue Exception => err
-      $vim_log.info "#{log_prefix}: returned from monitorUpdates via #{err.class} exception" if $vim_log
+      logger.info "#{log_prefix}: returned from monitorUpdates via #{err.class} exception" if logger
       @error = err
     end
   end
@@ -318,9 +318,9 @@ class MiqVim < MiqVimInventory
     stopUpdateMonitor
     begin
       if @updateThread != Thread.current && @updateThread.alive?
-        $vim_log.info "#{log_prefix}: waiting for Update Monitor Thread...Starting" if $vim_log
+        logger.info "#{log_prefix}: waiting for Update Monitor Thread...Starting" if logger
         @updateThread.join
-        $vim_log.info "#{log_prefix}: waiting for Update Monitor Thread...Complete" if $vim_log
+        logger.info "#{log_prefix}: waiting for Update Monitor Thread...Complete" if logger
       end
     rescue
     end

--- a/lib/VMwareWebService/MiqVim.rb
+++ b/lib/VMwareWebService/MiqVim.rb
@@ -279,16 +279,16 @@ class MiqVim < MiqVimInventory
   def start_monitor_updates_thread(preLoad)
     checkForOrphanedMonitors
     log_prefix          = "MiqVim.initialize (#{@connId})"
-    logger.info "#{log_prefix}: starting update monitor thread" if logger
+    logger.info "#{log_prefix}: starting update monitor thread"
     @updateThread = Thread.new { monitor(preLoad) }
     @updateThread[:vim_connection_id] = connId
-    logger.info "#{log_prefix}: waiting for update monitor to become ready" if logger
+    logger.info "#{log_prefix}: waiting for update monitor to become ready"
     until @updateMonitorReady
       raise @error unless @error.nil?
       break unless @updateThread.alive?
       Thread.pass
     end
-    logger.info "#{log_prefix}: update monitor ready" if logger
+    logger.info "#{log_prefix}: update monitor ready"
   end
 
   def checkForOrphanedMonitors
@@ -308,7 +308,7 @@ class MiqVim < MiqVimInventory
     begin
       monitorUpdates(preLoad)
     rescue Exception => err
-      logger.info "#{log_prefix}: returned from monitorUpdates via #{err.class} exception" if logger
+      logger.info "#{log_prefix}: returned from monitorUpdates via #{err.class} exception"
       @error = err
     end
   end
@@ -318,9 +318,9 @@ class MiqVim < MiqVimInventory
     stopUpdateMonitor
     begin
       if @updateThread != Thread.current && @updateThread.alive?
-        logger.info "#{log_prefix}: waiting for Update Monitor Thread...Starting" if logger
+        logger.info "#{log_prefix}: waiting for Update Monitor Thread...Starting"
         @updateThread.join
-        logger.info "#{log_prefix}: waiting for Update Monitor Thread...Complete" if logger
+        logger.info "#{log_prefix}: waiting for Update Monitor Thread...Complete"
       end
     rescue
     end

--- a/lib/VMwareWebService/MiqVimClientBase.rb
+++ b/lib/VMwareWebService/MiqVimClientBase.rb
@@ -24,8 +24,8 @@ class MiqVimClientBase < VimService
       http_client.receive_timeout       = @receiveTimeout
     end
 
-    on_log_header { |msg| $vim_log.info msg }
-    on_log_body   { |msg| $vim_log.debug msg } if $miq_wiredump
+    on_log_header { |msg| logger.info msg }
+    on_log_body   { |msg| logger.debug msg } if $miq_wiredump
 
     super(:uri => sdk_uri, :version => 1)
 
@@ -59,7 +59,7 @@ class MiqVimClientBase < VimService
   end
 
   def connect
-    $vim_log.debug "#{self.class.name}.connect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}" if $vim_log.debug?
+    logger.debug "#{self.class.name}.connect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}" if logger.debug?
     @connLock.synchronize(:EX) do
       return if @connected
       login(@sic.sessionManager, @username, @password)
@@ -68,7 +68,7 @@ class MiqVimClientBase < VimService
   end
 
   def disconnect
-    $vim_log.debug "#{self.class.name}.disconnect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}" if $vim_log.debug?
+    logger.debug "#{self.class.name}.disconnect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}" if logger.debug?
     @connLock.synchronize(:EX) do
       return unless @connected
       logout(@sic.sessionManager)

--- a/lib/VMwareWebService/MiqVimClientBase.rb
+++ b/lib/VMwareWebService/MiqVimClientBase.rb
@@ -59,7 +59,7 @@ class MiqVimClientBase < VimService
   end
 
   def connect
-    logger.debug "#{self.class.name}.connect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}" if logger.debug?
+    logger.debug "#{self.class.name}.connect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}".debug?
     @connLock.synchronize(:EX) do
       return if @connected
       login(@sic.sessionManager, @username, @password)
@@ -68,7 +68,7 @@ class MiqVimClientBase < VimService
   end
 
   def disconnect
-    logger.debug "#{self.class.name}.disconnect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}" if logger.debug?
+    logger.debug "#{self.class.name}.disconnect(#{@connId}): #{$PROGRAM_NAME} #{ARGV.join(' ')}".debug?
     @connLock.synchronize(:EX) do
       return unless @connected
       logout(@sic.sessionManager)

--- a/lib/VMwareWebService/MiqVimCluster.rb
+++ b/lib/VMwareWebService/MiqVimCluster.rb
@@ -1,4 +1,8 @@
+require 'VMwareWebService/logging'
+
 class MiqVimCluster
+  include VMwareWebService::Logging
+
   attr_reader :name, :invObj
 
   def initialize(invObj, ch)
@@ -44,9 +48,9 @@ class MiqVimCluster
       cs.vmFolder       = ah[:vmFolder]       unless ah[:vmFolder].nil?
     end
 
-    $vim_log.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: calling addHost_Task" if $vim_log
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: calling addHost_Task" if logger
     taskMor = @invObj.addHost_Task(@cMor, cspec, ah[:asConnected].to_s, ah[:resourcePool], ah[:license])
-    $vim_log.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: returned from addHost_Task" if $vim_log
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: returned from addHost_Task" if logger
     return taskMor unless ah[:wait]
     waitForTask(taskMor)
   end # def addHost

--- a/lib/VMwareWebService/MiqVimCluster.rb
+++ b/lib/VMwareWebService/MiqVimCluster.rb
@@ -48,9 +48,9 @@ class MiqVimCluster
       cs.vmFolder       = ah[:vmFolder]       unless ah[:vmFolder].nil?
     end
 
-    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: calling addHost_Task" if logger
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: calling addHost_Task"
     taskMor = @invObj.addHost_Task(@cMor, cspec, ah[:asConnected].to_s, ah[:resourcePool], ah[:license])
-    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: returned from addHost_Task" if logger
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addHost: returned from addHost_Task"
     return taskMor unless ah[:wait]
     waitForTask(taskMor)
   end # def addHost

--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -130,13 +130,13 @@ class MiqVimDataStore
 
     taskMor = nil
     if recurse
-      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastoreSubFolders_Task" if logger
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastoreSubFolders_Task"
       taskMor = @invObj.searchDatastoreSubFolders_Task(browserMor, dsPath, searchSpec)
-      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastoreSubFolders_Task" if logger
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastoreSubFolders_Task"
     else
-      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastore_Task" if logger
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastore_Task"
       taskMor = @invObj.searchDatastore_Task(browserMor, dsPath, searchSpec)
-      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastore_Task" if logger
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastore_Task"
     end
 
     retObj = waitForTask(taskMor)
@@ -203,9 +203,9 @@ class MiqVimDataStore
         hdbs.sortFoldersFirst = "true"
       end
 
-      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: calling searchDatastoreSubFolders_Task" if logger
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: calling searchDatastoreSubFolders_Task"
       taskMor = @invObj.searchDatastoreSubFolders_Task(browser_locked, "[#{@name}]", searchSpec)
-      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: returned from searchDatastoreSubFolders_Task" if logger
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: returned from searchDatastoreSubFolders_Task"
 
       retObj = waitForTask(taskMor)
       retObj = [retObj] unless retObj.kind_of?(Array)

--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -1,7 +1,10 @@
 require 'sync'
 require 'util/miq-extensions'  # Required patch to open-uri for get_file_content
+require 'VMwareWebService/logging'
 
 class MiqVimDataStore
+  include VMwareWebService::Logging
+
   attr_reader :accessible, :multipleHostAccess, :name, :dsType, :url, :freeBytes, :capacityBytes, :uncommitted, :invObj
 
   def initialize(invObj, dsh)
@@ -127,13 +130,13 @@ class MiqVimDataStore
 
     taskMor = nil
     if recurse
-      $vim_log.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastoreSubFolders_Task" if $vim_log
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastoreSubFolders_Task" if logger
       taskMor = @invObj.searchDatastoreSubFolders_Task(browserMor, dsPath, searchSpec)
-      $vim_log.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastoreSubFolders_Task" if $vim_log
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastoreSubFolders_Task" if logger
     else
-      $vim_log.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastore_Task" if $vim_log
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: calling searchDatastore_Task" if logger
       taskMor = @invObj.searchDatastore_Task(browserMor, dsPath, searchSpec)
-      $vim_log.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastore_Task" if $vim_log
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsSearch: returned from searchDatastore_Task" if logger
     end
 
     retObj = waitForTask(taskMor)
@@ -200,9 +203,9 @@ class MiqVimDataStore
         hdbs.sortFoldersFirst = "true"
       end
 
-      $vim_log.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: calling searchDatastoreSubFolders_Task" if $vim_log
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: calling searchDatastoreSubFolders_Task" if logger
       taskMor = @invObj.searchDatastoreSubFolders_Task(browser_locked, "[#{@name}]", searchSpec)
-      $vim_log.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: returned from searchDatastoreSubFolders_Task" if $vim_log
+      logger.info "MiqVimDataStore(#{@invObj.server}, #{@invObj.username}).dsHash_locked: returned from searchDatastoreSubFolders_Task" if logger
 
       retObj = waitForTask(taskMor)
       retObj = [retObj] unless retObj.kind_of?(Array)

--- a/lib/VMwareWebService/MiqVimDump.rb
+++ b/lib/VMwareWebService/MiqVimDump.rb
@@ -60,7 +60,7 @@ module MiqVimDump
 
   def indentedPrint(s, i)
     if @dumpToLog
-      $vim_log.debug @globalIndent + ("    " * i) + s.to_s
+      logger.debug @globalIndent + ("    " * i) + s.to_s
     else
       print @globalIndent + "    " * i
       puts s

--- a/lib/VMwareWebService/MiqVimEventHistoryCollector.rb
+++ b/lib/VMwareWebService/MiqVimEventHistoryCollector.rb
@@ -1,4 +1,8 @@
+require 'VMwareWebService/logging'
+
 class MiqVimEventHistoryCollector
+  include VMwareWebService::Logging
+
   attr_reader :invObj
 
   def initialize(invObj, eventFilterSpec = nil, pgSize = 20)
@@ -14,7 +18,7 @@ class MiqVimEventHistoryCollector
 
   def release
     return unless @eventHistoryCollector
-    $vim_log.info "MiqVimEventHistoryCollector.release: destroying #{@eventHistoryCollector}"
+    logger.info "MiqVimEventHistoryCollector.release: destroying #{@eventHistoryCollector}"
     @invObj.destroyCollector(@eventHistoryCollector)
     @eventHistoryCollector = nil
   end

--- a/lib/VMwareWebService/MiqVimFolder.rb
+++ b/lib/VMwareWebService/MiqVimFolder.rb
@@ -40,10 +40,10 @@ class MiqVimFolder
     hmor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
     pmor = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
 
-    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: calling registerVM_Task" if logger
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: calling registerVM_Task"
     taskMor = @invObj.registerVM_Task(@fMor, path, name, asTemplate.to_s, pmor, hmor)
-    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: returned from registerVM_Task" if logger
-    logger.debug "MiqVimFolder::registerVM: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: returned from registerVM_Task"
+    logger.debug "MiqVimFolder::registerVM: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end
 
@@ -69,9 +69,9 @@ class MiqVimFolder
       cs.vmFolder       = ah[:vmFolder]       unless ah[:vmFolder].nil?
     end
 
-    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: calling addStandaloneHost_Task" if logger
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: calling addStandaloneHost_Task"
     taskMor = @invObj.addStandaloneHost_Task(@fMor, cspec, ah[:asConnected].to_s, ah[:license])
-    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: returned from addStandaloneHost_Task" if logger
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: returned from addStandaloneHost_Task"
     return taskMor unless ah[:wait]
     waitForTask(taskMor)
   end # def addStandaloneHost
@@ -81,10 +81,10 @@ class MiqVimFolder
     oMor = nil
     oMor = (vCenterObject.kind_of?(Hash) ? vCenterObject['MOR'] : vCenterObject) if vCenterObject
 
-    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: calling moveIntoFolder_Task" if logger
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: calling moveIntoFolder_Task"
     taskMor = @invObj.moveIntoFolder_Task(@fMor, oMor)
-    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: returned from moveIntoFolder_Task" if logger
-    logger.debug "MiqVimFolder::moveIntoFolder: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: returned from moveIntoFolder_Task"
+    logger.debug "MiqVimFolder::moveIntoFolder: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end
 
@@ -100,10 +100,10 @@ class MiqVimFolder
     hMor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
     pMor = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
 
-    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM calling createVM_Task" if logger
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM calling createVM_Task"
     taskMor = @invObj.createVM_Task(@fMor, configSpec, pMor, hMor)
-    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM returned from createVM_Task" if logger
-    logger.debug "MiqVimFolder::createVM: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM returned from createVM_Task"
+    logger.debug "MiqVimFolder::createVM: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end
 

--- a/lib/VMwareWebService/MiqVimFolder.rb
+++ b/lib/VMwareWebService/MiqVimFolder.rb
@@ -1,4 +1,8 @@
+require 'VMwareWebService/logging'
+
 class MiqVimFolder
+  include VMwareWebService::Logging
+
   attr_reader :name, :invObj
 
   def initialize(invObj, fh)
@@ -36,10 +40,10 @@ class MiqVimFolder
     hmor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
     pmor = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
 
-    $vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: calling registerVM_Task" if $vim_log
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: calling registerVM_Task" if logger
     taskMor = @invObj.registerVM_Task(@fMor, path, name, asTemplate.to_s, pmor, hmor)
-    $vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: returned from registerVM_Task" if $vim_log
-    $vim_log.debug "MiqVimFolder::registerVM: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).registerVM: returned from registerVM_Task" if logger
+    logger.debug "MiqVimFolder::registerVM: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end
 
@@ -65,9 +69,9 @@ class MiqVimFolder
       cs.vmFolder       = ah[:vmFolder]       unless ah[:vmFolder].nil?
     end
 
-    $vim_log.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: calling addStandaloneHost_Task" if $vim_log
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: calling addStandaloneHost_Task" if logger
     taskMor = @invObj.addStandaloneHost_Task(@fMor, cspec, ah[:asConnected].to_s, ah[:license])
-    $vim_log.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: returned from addStandaloneHost_Task" if $vim_log
+    logger.info "MiqVimCluster(#{@invObj.server}, #{@invObj.username}).addStandaloneHost: returned from addStandaloneHost_Task" if logger
     return taskMor unless ah[:wait]
     waitForTask(taskMor)
   end # def addStandaloneHost
@@ -77,10 +81,10 @@ class MiqVimFolder
     oMor = nil
     oMor = (vCenterObject.kind_of?(Hash) ? vCenterObject['MOR'] : vCenterObject) if vCenterObject
 
-    $vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: calling moveIntoFolder_Task" if $vim_log
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: calling moveIntoFolder_Task" if logger
     taskMor = @invObj.moveIntoFolder_Task(@fMor, oMor)
-    $vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: returned from moveIntoFolder_Task" if $vim_log
-    $vim_log.debug "MiqVimFolder::moveIntoFolder: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).moveIntoFolder: returned from moveIntoFolder_Task" if logger
+    logger.debug "MiqVimFolder::moveIntoFolder: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end
 
@@ -96,10 +100,10 @@ class MiqVimFolder
     hMor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
     pMor = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
 
-    $vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM calling createVM_Task" if $vim_log
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM calling createVM_Task" if logger
     taskMor = @invObj.createVM_Task(@fMor, configSpec, pMor, hMor)
-    $vim_log.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM returned from createVM_Task" if $vim_log
-    $vim_log.debug "MiqVimFolder::createVM: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimFolder(#{@invObj.server}, #{@invObj.username}).createVM returned from createVM_Task" if logger
+    logger.debug "MiqVimFolder::createVM: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end
 

--- a/lib/VMwareWebService/MiqVimHost.rb
+++ b/lib/VMwareWebService/MiqVimHost.rb
@@ -3,6 +3,7 @@ require 'sync'
 require "ostruct"
 
 require 'more_core_extensions/core_ext/hash'
+require 'VMwareWebService/logging'
 require 'VMwareWebService/MiqHostDatastoreSystem'
 require 'VMwareWebService/MiqHostStorageSystem'
 require 'VMwareWebService/MiqHostFirewallSystem'
@@ -13,6 +14,8 @@ require 'VMwareWebService/MiqHostAdvancedOptionManager'
 require 'VMwareWebService/MiqHostSnmpSystem'
 
 class MiqVimHost
+  include VMwareWebService::Logging
+
   attr_reader :name, :invObj
 
   def initialize(invObj, hh)
@@ -107,49 +110,49 @@ class MiqVimHost
   end
 
   def enterMaintenanceMode(timeout = 0, evacuatePoweredOffVms = false, wait = true)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: calling enterMaintenanceMode_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: calling enterMaintenanceMode_Task" if logger
     taskMor = @invObj.enterMaintenanceMode_Task(@hMor, timeout, evacuatePoweredOffVms)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: returned from enterMaintenanceMode_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: returned from enterMaintenanceMode_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def exitMaintenanceMode(timeout = 0, wait = true)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: calling exitMaintenanceMode_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: calling exitMaintenanceMode_Task" if logger
     taskMor = @invObj.exitMaintenanceMode_Task(@hMor, timeout)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: returned from exitMaintenanceMode_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: returned from exitMaintenanceMode_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def powerDownHostToStandBy(timeout = 0, evacuatePoweredOffVms = false, wait = true)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: calling powerDownHostToStandBy_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: calling powerDownHostToStandBy_Task" if logger
     taskMor = @invObj.powerDownHostToStandBy_Task(@hMor, timeout, evacuatePoweredOffVms)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: returned from powerDownHostToStandBy_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: returned from powerDownHostToStandBy_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def powerUpHostFromStandBy(timeout = 0, wait = true)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: calling powerUpHostFromStandBy_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: calling powerUpHostFromStandBy_Task" if logger
     taskMor = @invObj.powerUpHostFromStandBy_Task(@hMor, timeout)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: returned from powerUpHostFromStandBy_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: returned from powerUpHostFromStandBy_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def rebootHost(force = false, wait = true)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: calling rebootHost_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: calling rebootHost_Task" if logger
     taskMor = @invObj.rebootHost_Task(@hMor, force)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: returned from rebootHost_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: returned from rebootHost_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def shutdownHost(force = false, wait = true)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: calling shutdownHost_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: calling shutdownHost_Task" if logger
     taskMor = @invObj.shutdownHost_Task(@hMor, force)
-    $vim_log.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: returned from shutdownHost_Task" if $vim_log
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: returned from shutdownHost_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end

--- a/lib/VMwareWebService/MiqVimHost.rb
+++ b/lib/VMwareWebService/MiqVimHost.rb
@@ -110,49 +110,49 @@ class MiqVimHost
   end
 
   def enterMaintenanceMode(timeout = 0, evacuatePoweredOffVms = false, wait = true)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: calling enterMaintenanceMode_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: calling enterMaintenanceMode_Task"
     taskMor = @invObj.enterMaintenanceMode_Task(@hMor, timeout, evacuatePoweredOffVms)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: returned from enterMaintenanceMode_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).enterMaintenanceMode: returned from enterMaintenanceMode_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def exitMaintenanceMode(timeout = 0, wait = true)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: calling exitMaintenanceMode_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: calling exitMaintenanceMode_Task"
     taskMor = @invObj.exitMaintenanceMode_Task(@hMor, timeout)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: returned from exitMaintenanceMode_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).exitMaintenanceMode: returned from exitMaintenanceMode_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def powerDownHostToStandBy(timeout = 0, evacuatePoweredOffVms = false, wait = true)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: calling powerDownHostToStandBy_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: calling powerDownHostToStandBy_Task"
     taskMor = @invObj.powerDownHostToStandBy_Task(@hMor, timeout, evacuatePoweredOffVms)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: returned from powerDownHostToStandBy_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerDownHostToStandBy: returned from powerDownHostToStandBy_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def powerUpHostFromStandBy(timeout = 0, wait = true)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: calling powerUpHostFromStandBy_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: calling powerUpHostFromStandBy_Task"
     taskMor = @invObj.powerUpHostFromStandBy_Task(@hMor, timeout)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: returned from powerUpHostFromStandBy_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).powerUpHostFromStandBy: returned from powerUpHostFromStandBy_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def rebootHost(force = false, wait = true)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: calling rebootHost_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: calling rebootHost_Task"
     taskMor = @invObj.rebootHost_Task(@hMor, force)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: returned from rebootHost_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).rebootHost: returned from rebootHost_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def shutdownHost(force = false, wait = true)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: calling shutdownHost_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: calling shutdownHost_Task"
     taskMor = @invObj.shutdownHost_Task(@hMor, force)
-    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: returned from shutdownHost_Task" if logger
+    logger.info "MiqVimHost(#{@invObj.server}, #{@invObj.username}).shutdownHost: returned from shutdownHost_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end

--- a/lib/VMwareWebService/MiqVimInventory.rb
+++ b/lib/VMwareWebService/MiqVimInventory.rb
@@ -25,19 +25,19 @@ class MiqVimInventory < MiqVimClientBase
     case cacheScope
     when :cache_scope_full
       @propMap = FullPropMap
-      $vim_log.info "MiqVimInventory: using property map FullPropMap"
+      logger.info "MiqVimInventory: using property map FullPropMap"
     when :cache_scope_ems_refresh
       @propMap = EmsRefreshPropMap
-      $vim_log.info "MiqVimInventory: using property map EmsRefreshPropMap"
+      logger.info "MiqVimInventory: using property map EmsRefreshPropMap"
     when :cache_scope_core
       @propMap = CorePropMap
-      $vim_log.info "MiqVimInventory: using property map CorePropMap"
+      logger.info "MiqVimInventory: using property map CorePropMap"
     when :cache_scope_event_monitor
       @propMap = EventMonitorPropMap
-      $vim_log.info "MiqVimInventory: using property map EventMonitorPropMap"
+      logger.info "MiqVimInventory: using property map EventMonitorPropMap"
     else
       @propMap = FullPropMap
-      $vim_log.info "MiqVimInventory: unrecognized cache scope #{cacheScope}, using FullPropMap"
+      logger.info "MiqVimInventory: unrecognized cache scope #{cacheScope}, using FullPropMap"
     end
 
     # If we are connected to a virtual center then we can access additional properties
@@ -87,11 +87,11 @@ class MiqVimInventory < MiqVimClientBase
 
         unless instance_variable_get(hnm).nil?
           hnmc = instance_variable_get(hnm).keys.length
-          $vim_log.info "#{pref}#{hnm}: #{hnmc}"
+          logger.info "#{pref}#{hnm}: #{hnmc}"
         end
         unless instance_variable_get(hn).nil?
           hnc = instance_variable_get(hn).keys.length
-          $vim_log.info "#{pref}#{hn}: #{hnc}"
+          logger.info "#{pref}#{hn}: #{hnc}"
         end
       end
     end
@@ -107,37 +107,37 @@ class MiqVimInventory < MiqVimClientBase
         hashByKey = pm[:keyPath] ? instance_variable_get(hn) : nil
 
         if hashByMor.nil?
-          $vim_log.info "#{pref}#{hnm}: is nil"
+          logger.info "#{pref}#{hnm}: is nil"
           next
         end
 
         keya = hashByMor.keys
         obja = hashByMor.values
-        $vim_log.info "#{pref}#{hnm}: #keys = #{keya.length}"
-        $vim_log.info "#{pref}#{hnm}: #objects = #{obja.length}"
+        logger.info "#{pref}#{hnm}: #keys = #{keya.length}"
+        logger.info "#{pref}#{hnm}: #objects = #{obja.length}"
         obja.compact!
         obja.uniq!
-        $vim_log.info "#{pref}#{hnm}: #unique non-nill objects = #{obja.length}"
+        logger.info "#{pref}#{hnm}: #unique non-nill objects = #{obja.length}"
 
         unless hashByKey.nil?
           keyb = hashByKey.keys
           objb = hashByKey.values
-          $vim_log.info "#{pref}#{hn}: #keys = #{keyb.length}"
-          $vim_log.info "#{pref}#{hn}: #objects = #{objb.length}"
+          logger.info "#{pref}#{hn}: #keys = #{keyb.length}"
+          logger.info "#{pref}#{hn}: #objects = #{objb.length}"
           objb.compact!
           objb.uniq!
-          $vim_log.info "#{pref}#{hn}: #unique non-nill objects = #{objb.length}"
+          logger.info "#{pref}#{hn}: #unique non-nill objects = #{objb.length}"
           obja.concat(objb).uniq!
         end
-        $vim_log.info "#{pref}TOTAL: #unique non-nill objects = #{obja.length}"
+        logger.info "#{pref}TOTAL: #unique non-nill objects = #{obja.length}"
         cacheSz = Marshal.dump(obja).length
-        $vim_log.info "#{pref}TOTAL: size of objects = #{cacheSz}"
-        $vim_log.info "#{pref}****"
+        logger.info "#{pref}TOTAL: size of objects = #{cacheSz}"
+        logger.info "#{pref}****"
         totalCacheSz += cacheSz
       end
-      $vim_log.info "#{pref}****************"
-      $vim_log.info "#{pref}TOTAL: cache size = #{totalCacheSz}"
-      $vim_log.info "#{pref}****************"
+      logger.info "#{pref}****************"
+      logger.info "#{pref}TOTAL: cache size = #{totalCacheSz}"
+      logger.info "#{pref}****************"
     end
     totalCacheSz
   end
@@ -218,7 +218,7 @@ class MiqVimInventory < MiqVimClientBase
   end
 
   def resetCache
-    $vim_log.info "MiqVimInventory.resetCache: clearing cache for #{@connId}"
+    logger.info "MiqVimInventory.resetCache: clearing cache for #{@connId}"
     @cacheLock.synchronize(:EX) do
       @inventoryHash = nil
 
@@ -227,7 +227,7 @@ class MiqVimInventory < MiqVimClientBase
         instance_variable_set(pm[:baseName], nil)
       end
     end
-    $vim_log.info "MiqVimInventory.resetCache: cleared cache for #{@connId}"
+    logger.info "MiqVimInventory.resetCache: cleared cache for #{@connId}"
   end # def resetCache
 
   def currentSession
@@ -238,11 +238,11 @@ class MiqVimInventory < MiqVimClientBase
     return false unless @alive
     begin
         unless currentSession
-          $vim_log.info "MiqVimInventory.isAlive?: Current session no longer exists."
+          logger.info "MiqVimInventory.isAlive?: Current session no longer exists."
           @alive = false
         end
       rescue Exception => err
-        $vim_log.info "MiqVimInventory.isAlive?: Could not access connection - #{err}"
+        logger.info "MiqVimInventory.isAlive?: Could not access connection - #{err}"
         @alive = false
       end
     @alive
@@ -277,9 +277,9 @@ class MiqVimInventory < MiqVimClientBase
     if keyPath
       key = props.fetch_path(keyPath)
       if !key
-        $vim_log.debug "hashObj: key is nil for #{mor}: #{keyPath}"
+        logger.debug "hashObj: key is nil for #{mor}: #{keyPath}"
       elsif key.empty?
-        $vim_log.debug "hashObj: key is empty for #{mor}: #{keyPath}"
+        logger.debug "hashObj: key is empty for #{mor}: #{keyPath}"
         key = nil
         props.store_path(keyPath, nil)
       end
@@ -490,7 +490,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "virtualMachines_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@virtualMachines) if @virtualMachines
 
-    $vim_log.info "MiqVimInventory.virtualMachines_locked: loading VirtualMachine cache for #{@connId}"
+    logger.info "MiqVimInventory.virtualMachines_locked: loading VirtualMachine cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -504,7 +504,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.virtualMachines_locked: loaded VirtualMachine cache for #{@connId}"
+    logger.info "MiqVimInventory.virtualMachines_locked: loaded VirtualMachine cache for #{@connId}"
 
     @virtualMachines
   end # def virtualMachines_locked
@@ -616,7 +616,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "computeResources_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@computeResources) if @computeResources
 
-    $vim_log.info "MiqVimInventory.computeResources_locked: loading ComputeResource cache for #{@connId}"
+    logger.info "MiqVimInventory.computeResources_locked: loading ComputeResource cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -630,7 +630,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.computeResources_locked: loaded ComputeResource cache for #{@connId}"
+    logger.info "MiqVimInventory.computeResources_locked: loaded ComputeResource cache for #{@connId}"
 
     @computeResources
   end # def computeResources_locked
@@ -719,7 +719,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "clusterComputeResources_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@clusterComputeResources) if @clusterComputeResources
 
-    $vim_log.info "MiqVimInventory.clusterComputeResources_locked: loading ClusterComputeResource cache for #{@connId}"
+    logger.info "MiqVimInventory.clusterComputeResources_locked: loading ClusterComputeResource cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -733,7 +733,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.clusterComputeResources_locked: loaded ClusterComputeResource cache for #{@connId}"
+    logger.info "MiqVimInventory.clusterComputeResources_locked: loaded ClusterComputeResource cache for #{@connId}"
 
     @clusterComputeResources
   end # def clusterComputeResources_locked
@@ -822,7 +822,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "resourcePools_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@resourcePools) if @resourcePools
 
-    $vim_log.info "MiqVimInventory.resourcePools_locked: loading ResourcePool cache for #{@connId}"
+    logger.info "MiqVimInventory.resourcePools_locked: loading ResourcePool cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -836,7 +836,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.resourcePools_locked: loaded ResourcePool cache for #{@connId}"
+    logger.info "MiqVimInventory.resourcePools_locked: loaded ResourcePool cache for #{@connId}"
 
     @resourcePools
   end # def resourcePools_locked
@@ -934,7 +934,7 @@ class MiqVimInventory < MiqVimClientBase
 
     return(@virtualApps) if @virtualApps
 
-    $vim_log.info "MiqVimInventory.virtualApps_locked: loading VirtualApp cache for #{@connId}"
+    logger.info "MiqVimInventory.virtualApps_locked: loading VirtualApp cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -948,7 +948,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.virtualApps_locked: loaded VirtualApp cache for #{@connId}"
+    logger.info "MiqVimInventory.virtualApps_locked: loaded VirtualApp cache for #{@connId}"
 
     @virtualApps
   end # def virtualApps_locked
@@ -1037,7 +1037,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "folders_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@folders) if @folders
 
-    $vim_log.info "MiqVimInventory.folders_locked: loading Folder cache for #{@connId}"
+    logger.info "MiqVimInventory.folders_locked: loading Folder cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1051,7 +1051,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.folders_locked: loaded Folder cache for #{@connId}"
+    logger.info "MiqVimInventory.folders_locked: loaded Folder cache for #{@connId}"
 
     @folders
   end # def folders_locked
@@ -1140,7 +1140,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "datacenters_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@datacenters) if @datacenters
 
-    $vim_log.info "MiqVimInventory.datacenters_locked: loading Datacenter cache for #{@connId}"
+    logger.info "MiqVimInventory.datacenters_locked: loading Datacenter cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1154,7 +1154,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.datacenters_locked: loaded Datacenter cache for #{@connId}"
+    logger.info "MiqVimInventory.datacenters_locked: loaded Datacenter cache for #{@connId}"
 
     @datacenters
   end # def datacenters_locked
@@ -1243,7 +1243,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "hostSystems_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@hostSystems) if @hostSystems
 
-    $vim_log.info "MiqVimInventory.hostSystems_locked: loading HostSystem cache for #{@connId}"
+    logger.info "MiqVimInventory.hostSystems_locked: loading HostSystem cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1257,7 +1257,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.hostSystems_locked: loaded HostSystem cache for #{@connId}"
+    logger.info "MiqVimInventory.hostSystems_locked: loaded HostSystem cache for #{@connId}"
 
     @hostSystems
   end # def hostSystems_locked
@@ -1368,7 +1368,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "dataStores_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@dataStores) if @dataStores
 
-    $vim_log.info "MiqVimInventory.dataStores_locked: loading Datastore cache for #{@connId}"
+    logger.info "MiqVimInventory.dataStores_locked: loading Datastore cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1382,7 +1382,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.dataStores_locked: loaded Datastore cache for #{@connId}"
+    logger.info "MiqVimInventory.dataStores_locked: loaded Datastore cache for #{@connId}"
 
     @dataStores
   end # def dataStores_locked
@@ -1487,7 +1487,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "dvPortgroups_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@dvPortgroups) if @dvPortgroups
 
-    $vim_log.info "MiqVimInventory.dvPortgroups_locked: loading DV Portgroup cache for #{@connId}"
+    logger.info "MiqVimInventory.dvPortgroups_locked: loading DV Portgroup cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1501,7 +1501,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.dvPortgroups_locked: loaded DV Portgroup cache for #{@connId}"
+    logger.info "MiqVimInventory.dvPortgroups_locked: loaded DV Portgroup cache for #{@connId}"
 
     @dvPortgroups
   end # def dvPortgroups_locked
@@ -1575,7 +1575,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "dvSwitches_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@dvSwithces) if @dvSwitches
 
-    $vim_log.info "MiqVimInventory.dvSwitches_locked: loading DV Switch cache for #{@connId}"
+    logger.info "MiqVimInventory.dvSwitches_locked: loading DV Switch cache for #{@connId}"
 
     base_class    = 'DistributedVirtualSwitch'.freeze
     child_classes = VimClass.child_classes(base_class)
@@ -1595,7 +1595,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.dvSwitches_locked: loaded DV Switch cache for #{@connId}"
+    logger.info "MiqVimInventory.dvSwitches_locked: loaded DV Switch cache for #{@connId}"
 
     @dvSwitches
   end # def dvSwitches_locked
@@ -1668,7 +1668,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "storagePods_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@storagePods) if @storagePods
 
-    $vim_log.info "MiqVimInventory.storagePods_locked: loading Datastore Cluster cache for #{@connId}"
+    logger.info "MiqVimInventory.storagePods_locked: loading Datastore Cluster cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1682,7 +1682,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.storagePods_locked: loaded Datastore Cluster cache for #{@connId}"
+    logger.info "MiqVimInventory.storagePods_locked: loaded Datastore Cluster cache for #{@connId}"
 
     @storagePods
   end # def storagePods_locked
@@ -1760,7 +1760,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "licenseManagers_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@licenseManagers) if @licenseManagers
 
-    $vim_log.info "MiqVimInventory.licenseManagers_locked: loading LicenseManager cache for #{@connId}"
+    logger.info "MiqVimInventory.licenseManagers_locked: loading LicenseManager cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1774,7 +1774,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.licenseManagers_locked: loaded LicenseManager cache for #{@connId}"
+    logger.info "MiqVimInventory.licenseManagers_locked: loaded LicenseManager cache for #{@connId}"
 
     @licenseManagers
   end # def licenseManagers_locked
@@ -1870,7 +1870,7 @@ class MiqVimInventory < MiqVimClientBase
     raise "extensionManagers_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@extensionManagers) if @extensionManagers
 
-    $vim_log.info "MiqVimInventory.extensionManagers_locked: loading ExtensionManager cache for #{@connId}"
+    logger.info "MiqVimInventory.extensionManagers_locked: loading ExtensionManager cache for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
@@ -1884,7 +1884,7 @@ class MiqVimInventory < MiqVimClientBase
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.extensionManagers_locked: loaded ExtensionManager cache for #{@connId}"
+    logger.info "MiqVimInventory.extensionManagers_locked: loaded ExtensionManager cache for #{@connId}"
 
     @extensionManagers
   end # def extensionManagers_locked
@@ -1976,22 +1976,22 @@ class MiqVimInventory < MiqVimClientBase
     raise "inventoryHash_locked: cache lock not held" unless @cacheLock.sync_locked?
     return(@inventoryHash) if @inventoryHash
 
-    $vim_log.info "MiqVimInventory.inventoryHash_locked: loading inventoryHash for #{@connId}"
+    logger.info "MiqVimInventory.inventoryHash_locked: loading inventoryHash for #{@connId}"
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-      $vim_log.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: calling retrieveProperties" if $vim_log
+      logger.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: calling retrieveProperties" if logger
 
       @inventoryHash = {}
       retrievePropertiesIter(@propCol, @spec) do |oc|
         (@inventoryHash[oc.obj.vimType] ||= []) << oc.obj
       end
 
-      $vim_log.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: returned from retrieveProperties" if $vim_log
+      logger.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: returned from retrieveProperties" if logger
     ensure
       @cacheLock.sync_unlock if unlock
     end
-    $vim_log.info "MiqVimInventory.inventoryHash_locked: loaded inventoryHash for #{@connId}"
+    logger.info "MiqVimInventory.inventoryHash_locked: loaded inventoryHash for #{@connId}"
 
     @inventoryHash
   end
@@ -2008,9 +2008,9 @@ class MiqVimInventory < MiqVimClientBase
   # Generate a user event associated with the given managed object.
   #
   def logUserEvent(entity, msg)
-    $vim_log.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: calling logUserEvent" if $vim_log
+    logger.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: calling logUserEvent" if logger
     super(@sic.eventManager, entity, msg)
-    $vim_log.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: returned from logUserEvent" if $vim_log
+    logger.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: returned from logUserEvent" if logger
   end
 
   ##################################
@@ -2183,13 +2183,13 @@ class MiqVimInventory < MiqVimClientBase
 
   def getTaskMor(tmor)
     if tmor.respond_to?(:vimType)
-      $vim_log.debug "getTaskMor: returning #{tmor}, no search"
+      logger.debug "getTaskMor: returning #{tmor}, no search"
       return tmor
     else
-      $vim_log.debug "getTaskMor: searching for task #{tmor}"
+      logger.debug "getTaskMor: searching for task #{tmor}"
       getTasks.each do |tmo|
         if tmo.to_str == tmor
-          $vim_log.debug "getTaskMor: returning #{tmo} (#{tmo.vimType})"
+          logger.debug "getTaskMor: returning #{tmo} (#{tmo.vimType})"
           return tmo
         end
       end
@@ -2204,7 +2204,7 @@ class MiqVimInventory < MiqVimClientBase
   def waitForTask(tmor, className = nil)
     className ||= self.class.to_s
 
-    $vim_log.info "#{className}(#{@server}, #{@username})::waitForTask(#{tmor})" if $vim_log
+    logger.info "#{className}(#{@server}, #{@username})::waitForTask(#{tmor})" if logger
     args = VimArray.new("ArrayOfPropertyFilterSpec") do |pfsa|
       pfsa << VimHash.new("PropertyFilterSpec") do |pfs|
         pfs.propSet = VimArray.new("ArrayOfPropertySpec") do |psa|
@@ -2240,14 +2240,14 @@ class MiqVimInventory < MiqVimClientBase
     end
 
     raise VimFault.new(error) if state == TaskInfoState::Error
-    $vim_log.info "#{className}(#{@server}, #{@username})::waitForTask: result = #{result}" if $vim_log
+    logger.info "#{className}(#{@server}, #{@username})::waitForTask: result = #{result}" if logger
     result
   end # def waitForTask
 
   def pollTask(tmor, className = nil)
     className ||= self.class.to_s
 
-    $vim_log.info "#{className}(#{@server}, #{@username})::pollTask(#{tmor})" if $vim_log
+    logger.info "#{className}(#{@server}, #{@username})::pollTask(#{tmor})" if logger
     args = VimArray.new("ArrayOfPropertyFilterSpec") do |pfsa|
       pfsa << VimHash.new("PropertyFilterSpec") do |pfs|
         pfs.propSet = VimArray.new("ArrayOfPropertySpec") do |psa|
@@ -2323,9 +2323,9 @@ class MiqVimInventory < MiqVimClientBase
       end
     end
 
-    $vim_log.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: calling retrieveProperties(#{mo.vimType})" if $vim_log
+    logger.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: calling retrieveProperties(#{mo.vimType})" if logger
     oca = retrievePropertiesCompat(@propCol, pfSpec)
-    $vim_log.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: return from retrieveProperties(#{mo.vimType})" if $vim_log
+    logger.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: return from retrieveProperties(#{mo.vimType})" if logger
 
     return nil if !oca || !oca[0] || !oca[0].propSet
 

--- a/lib/VMwareWebService/MiqVimInventory.rb
+++ b/lib/VMwareWebService/MiqVimInventory.rb
@@ -1980,14 +1980,14 @@ class MiqVimInventory < MiqVimClientBase
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-      logger.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: calling retrieveProperties" if logger
+      logger.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: calling retrieveProperties"
 
       @inventoryHash = {}
       retrievePropertiesIter(@propCol, @spec) do |oc|
         (@inventoryHash[oc.obj.vimType] ||= []) << oc.obj
       end
 
-      logger.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: returned from retrieveProperties" if logger
+      logger.info "MiqVimInventory(#{@server}, #{@username}).inventoryHash_locked: returned from retrieveProperties"
     ensure
       @cacheLock.sync_unlock if unlock
     end
@@ -2008,9 +2008,9 @@ class MiqVimInventory < MiqVimClientBase
   # Generate a user event associated with the given managed object.
   #
   def logUserEvent(entity, msg)
-    logger.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: calling logUserEvent" if logger
+    logger.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: calling logUserEvent"
     super(@sic.eventManager, entity, msg)
-    logger.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: returned from logUserEvent" if logger
+    logger.info "MiqVimInventory(#{@server}, #{@username}).logUserEvent: returned from logUserEvent"
   end
 
   ##################################
@@ -2204,7 +2204,7 @@ class MiqVimInventory < MiqVimClientBase
   def waitForTask(tmor, className = nil)
     className ||= self.class.to_s
 
-    logger.info "#{className}(#{@server}, #{@username})::waitForTask(#{tmor})" if logger
+    logger.info "#{className}(#{@server}, #{@username})::waitForTask(#{tmor})"
     args = VimArray.new("ArrayOfPropertyFilterSpec") do |pfsa|
       pfsa << VimHash.new("PropertyFilterSpec") do |pfs|
         pfs.propSet = VimArray.new("ArrayOfPropertySpec") do |psa|
@@ -2240,14 +2240,14 @@ class MiqVimInventory < MiqVimClientBase
     end
 
     raise VimFault.new(error) if state == TaskInfoState::Error
-    logger.info "#{className}(#{@server}, #{@username})::waitForTask: result = #{result}" if logger
+    logger.info "#{className}(#{@server}, #{@username})::waitForTask: result = #{result}"
     result
   end # def waitForTask
 
   def pollTask(tmor, className = nil)
     className ||= self.class.to_s
 
-    logger.info "#{className}(#{@server}, #{@username})::pollTask(#{tmor})" if logger
+    logger.info "#{className}(#{@server}, #{@username})::pollTask(#{tmor})"
     args = VimArray.new("ArrayOfPropertyFilterSpec") do |pfsa|
       pfsa << VimHash.new("PropertyFilterSpec") do |pfs|
         pfs.propSet = VimArray.new("ArrayOfPropertySpec") do |psa|
@@ -2323,9 +2323,9 @@ class MiqVimInventory < MiqVimClientBase
       end
     end
 
-    logger.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: calling retrieveProperties(#{mo.vimType})" if logger
+    logger.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: calling retrieveProperties(#{mo.vimType})"
     oca = retrievePropertiesCompat(@propCol, pfSpec)
-    logger.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: return from retrieveProperties(#{mo.vimType})" if logger
+    logger.info "MiqVimInventory(#{@server}, #{@username}).getMoProp_local: return from retrieveProperties(#{mo.vimType})"
 
     return nil if !oca || !oca[0] || !oca[0].propSet
 

--- a/lib/VMwareWebService/MiqVimPerfHistory.rb
+++ b/lib/VMwareWebService/MiqVimPerfHistory.rb
@@ -98,9 +98,9 @@ class MiqVimPerfHistory
   end
 
   def queryProviderSummary(mor)
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: calling queryPerfProviderSummary" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: calling queryPerfProviderSummary"
     psum = @invObj.queryPerfProviderSummary(@perfManager, mor)
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: returned from queryPerfProviderSummary" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: returned from queryPerfProviderSummary"
     (psum)
   end
 
@@ -111,9 +111,9 @@ class MiqVimPerfHistory
       beginTime  = ah[:beginTime] || nil
       endTime    = ah[:endTime] || nil
     end
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: calling queryAvailablePerfMetric" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: calling queryAvailablePerfMetric"
     pmids = @invObj.queryAvailablePerfMetric(@perfManager, mor, beginTime, endTime, intervalId)
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: returned from queryAvailablePerfMetric" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: returned from queryAvailablePerfMetric"
     (pmids)
   end
 
@@ -124,9 +124,9 @@ class MiqVimPerfHistory
     ah[:entity]     = entnty
     pqs             = getPerfQuerySpec(ah)
 
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: calling queryPerf" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: calling queryPerf"
     umPem = @invObj.queryPerf(@perfManager, pqs)[0]
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: returned from queryPerf" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: returned from queryPerf"
 
     #
     # Construct an array of (timestamp, value) pairs.
@@ -154,9 +154,9 @@ class MiqVimPerfHistory
       aa.each { |ah| pqsa << getPerfQuerySpec(ah) }
     end
 
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: calling queryPerf" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: calling queryPerf"
     pema = @invObj.queryPerf(@perfManager, querySpec)
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: returned from queryPerf" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: returned from queryPerf"
 
     return(nil) unless pema
 
@@ -168,9 +168,9 @@ class MiqVimPerfHistory
     ah[:entity]     = entnty
     pqs             = getPerfQuerySpec(ah)
 
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: calling queryPerfComposite" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: calling queryPerfComposite"
     umPem = @invObj.queryPerfComposite(@perfManager, pqs)
-    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: returned from queryPerfComposite" if logger
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: returned from queryPerfComposite"
 
     umPem['childEntity'] = [umPem['childEntity']] if umPem['childEntity'].kind_of? Hash
 

--- a/lib/VMwareWebService/MiqVimPerfHistory.rb
+++ b/lib/VMwareWebService/MiqVimPerfHistory.rb
@@ -1,6 +1,9 @@
 require 'date'
+require 'VMwareWebService/logging'
 
 class MiqVimPerfHistory
+  include VMwareWebService::Logging
+
   attr_reader :invObj
 
   def initialize(invObj)
@@ -95,9 +98,9 @@ class MiqVimPerfHistory
   end
 
   def queryProviderSummary(mor)
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: calling queryPerfProviderSummary" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: calling queryPerfProviderSummary" if logger
     psum = @invObj.queryPerfProviderSummary(@perfManager, mor)
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: returned from queryPerfProviderSummary" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryProviderSummary: returned from queryPerfProviderSummary" if logger
     (psum)
   end
 
@@ -108,9 +111,9 @@ class MiqVimPerfHistory
       beginTime  = ah[:beginTime] || nil
       endTime    = ah[:endTime] || nil
     end
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: calling queryAvailablePerfMetric" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: calling queryAvailablePerfMetric" if logger
     pmids = @invObj.queryAvailablePerfMetric(@perfManager, mor, beginTime, endTime, intervalId)
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: returned from queryAvailablePerfMetric" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).availMetricsForEntity: returned from queryAvailablePerfMetric" if logger
     (pmids)
   end
 
@@ -121,9 +124,9 @@ class MiqVimPerfHistory
     ah[:entity]     = entnty
     pqs             = getPerfQuerySpec(ah)
 
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: calling queryPerf" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: calling queryPerf" if logger
     umPem = @invObj.queryPerf(@perfManager, pqs)[0]
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: returned from queryPerf" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerf: returned from queryPerf" if logger
 
     #
     # Construct an array of (timestamp, value) pairs.
@@ -151,9 +154,9 @@ class MiqVimPerfHistory
       aa.each { |ah| pqsa << getPerfQuerySpec(ah) }
     end
 
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: calling queryPerf" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: calling queryPerf" if logger
     pema = @invObj.queryPerf(@perfManager, querySpec)
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: returned from queryPerf" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfMulti: returned from queryPerf" if logger
 
     return(nil) unless pema
 
@@ -165,9 +168,9 @@ class MiqVimPerfHistory
     ah[:entity]     = entnty
     pqs             = getPerfQuerySpec(ah)
 
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: calling queryPerfComposite" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: calling queryPerfComposite" if logger
     umPem = @invObj.queryPerfComposite(@perfManager, pqs)
-    $vim_log.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: returned from queryPerfComposite" if $vim_log
+    logger.info "MiqVimPerfHistory(#{@invObj.server}, #{@invObj.username}).queryPerfComposite: returned from queryPerfComposite" if logger
 
     umPem['childEntity'] = [umPem['childEntity']] if umPem['childEntity'].kind_of? Hash
 

--- a/lib/VMwareWebService/MiqVimUpdate.rb
+++ b/lib/VMwareWebService/MiqVimUpdate.rb
@@ -27,9 +27,9 @@ module MiqVimUpdate
 
     while truncated
       begin
-        logger.info "#{log_prefix}: call to waitForUpdates...Starting" if logger
+        logger.info "#{log_prefix}: call to waitForUpdates...Starting"
         updateSet = waitForUpdatesEx(@umPropCol, version, wait_options)
-        logger.info "#{log_prefix}: call to waitForUpdates...Complete" if logger
+        logger.info "#{log_prefix}: call to waitForUpdates...Complete"
 
         version   = updateSet.version
         truncated = updateSet.truncated
@@ -46,7 +46,7 @@ module MiqVimUpdate
         # Help out the Ruby Garbage Collector by resetting variables pointing to large objects back to nil
         updateSet = nil
       rescue HTTPClient::ReceiveTimeoutError => terr
-        logger.info "#{log_prefix}: call to waitForUpdates...Timeout" if logger
+        logger.info "#{log_prefix}: call to waitForUpdates...Timeout"
         raise terr if !isAlive?
         retry
       end
@@ -58,9 +58,9 @@ module MiqVimUpdate
   def monitorUpdatesSince(version)
     log_prefix = "MiqVimUpdate.monitorUpdatesSince (#{@connId})"
     begin
-      logger.info "#{log_prefix}: call to waitForUpdates...Starting (version = #{version})" if logger
+      logger.info "#{log_prefix}: call to waitForUpdates...Starting (version = #{version})"
       updateSet = waitForUpdatesEx(@umPropCol, version, :max_wait => @maxWait)
-      logger.info "#{log_prefix}: call to waitForUpdates...Complete (version = #{version})" if logger
+      logger.info "#{log_prefix}: call to waitForUpdates...Complete (version = #{version})"
       return version if updateSet.nil?
 
       version = updateSet.version
@@ -70,11 +70,11 @@ module MiqVimUpdate
       updateSet.filterSet.each do |fu|
         next if fu.filter != @filterSpecRef
         fu.objectSet.each do |objUpdate|
-          logger.info "#{log_prefix}: applying update...Starting (version = #{version})" if logger
+          logger.info "#{log_prefix}: applying update...Starting (version = #{version})"
           @cacheLock.synchronize(:EX) do
             updateObject(objUpdate)
           end
-          logger.info "#{log_prefix}: applying update...Complete (version = #{version})" if logger
+          logger.info "#{log_prefix}: applying update...Complete (version = #{version})"
           Thread.pass
         end
       end # updateSet.filterSet.each
@@ -82,7 +82,7 @@ module MiqVimUpdate
       updateSet = nil
       return version
     rescue HTTPClient::ReceiveTimeoutError => terr
-      logger.info "#{log_prefix}: call to waitForUpdates...Timeout (version = #{version})" if logger
+      logger.info "#{log_prefix}: call to waitForUpdates...Timeout (version = #{version})"
       retry if isAlive?
       logger.warn "#{log_prefix}: connection lost"
       raise terr

--- a/lib/VMwareWebService/MiqVimUpdate.rb
+++ b/lib/VMwareWebService/MiqVimUpdate.rb
@@ -27,9 +27,9 @@ module MiqVimUpdate
 
     while truncated
       begin
-        $vim_log.info "#{log_prefix}: call to waitForUpdates...Starting" if $vim_log
+        logger.info "#{log_prefix}: call to waitForUpdates...Starting" if logger
         updateSet = waitForUpdatesEx(@umPropCol, version, wait_options)
-        $vim_log.info "#{log_prefix}: call to waitForUpdates...Complete" if $vim_log
+        logger.info "#{log_prefix}: call to waitForUpdates...Complete" if logger
 
         version   = updateSet.version
         truncated = updateSet.truncated
@@ -46,7 +46,7 @@ module MiqVimUpdate
         # Help out the Ruby Garbage Collector by resetting variables pointing to large objects back to nil
         updateSet = nil
       rescue HTTPClient::ReceiveTimeoutError => terr
-        $vim_log.info "#{log_prefix}: call to waitForUpdates...Timeout" if $vim_log
+        logger.info "#{log_prefix}: call to waitForUpdates...Timeout" if logger
         raise terr if !isAlive?
         retry
       end
@@ -58,9 +58,9 @@ module MiqVimUpdate
   def monitorUpdatesSince(version)
     log_prefix = "MiqVimUpdate.monitorUpdatesSince (#{@connId})"
     begin
-      $vim_log.info "#{log_prefix}: call to waitForUpdates...Starting (version = #{version})" if $vim_log
+      logger.info "#{log_prefix}: call to waitForUpdates...Starting (version = #{version})" if logger
       updateSet = waitForUpdatesEx(@umPropCol, version, :max_wait => @maxWait)
-      $vim_log.info "#{log_prefix}: call to waitForUpdates...Complete (version = #{version})" if $vim_log
+      logger.info "#{log_prefix}: call to waitForUpdates...Complete (version = #{version})" if logger
       return version if updateSet.nil?
 
       version = updateSet.version
@@ -70,11 +70,11 @@ module MiqVimUpdate
       updateSet.filterSet.each do |fu|
         next if fu.filter != @filterSpecRef
         fu.objectSet.each do |objUpdate|
-          $vim_log.info "#{log_prefix}: applying update...Starting (version = #{version})" if $vim_log
+          logger.info "#{log_prefix}: applying update...Starting (version = #{version})" if logger
           @cacheLock.synchronize(:EX) do
             updateObject(objUpdate)
           end
-          $vim_log.info "#{log_prefix}: applying update...Complete (version = #{version})" if $vim_log
+          logger.info "#{log_prefix}: applying update...Complete (version = #{version})" if logger
           Thread.pass
         end
       end # updateSet.filterSet.each
@@ -82,9 +82,9 @@ module MiqVimUpdate
       updateSet = nil
       return version
     rescue HTTPClient::ReceiveTimeoutError => terr
-      $vim_log.info "#{log_prefix}: call to waitForUpdates...Timeout (version = #{version})" if $vim_log
+      logger.info "#{log_prefix}: call to waitForUpdates...Timeout (version = #{version})" if logger
       retry if isAlive?
-      $vim_log.warn "#{log_prefix}: connection lost"
+      logger.warn "#{log_prefix}: connection lost"
       raise terr
     end
   end
@@ -97,7 +97,7 @@ module MiqVimUpdate
     @debugUpdates   = false if @debugUpdates.nil?
     @dumpToLog      = true  if @debugUpdates
 
-    $vim_log.debug "#{log_prefix}: debugUpdates = #{@debugUpdates}"
+    logger.debug "#{log_prefix}: debugUpdates = #{@debugUpdates}"
 
     begin
       @umPropCol     = @sic.propertyCollector
@@ -116,18 +116,18 @@ module MiqVimUpdate
       # Ignore signals, except TERM
     rescue => herr
       if herr.respond_to?(:reason) && herr.reason == 'The task was canceled by a user.'
-        $vim_log.info "#{log_prefix}: waitForUpdates canceled"
+        logger.info "#{log_prefix}: waitForUpdates canceled"
       else
-        $vim_log.error "******* #{herr.class}"
-        $vim_log.error herr.to_s
-        $vim_log.error herr.backtrace.join("\n") unless herr.kind_of?(HTTPClient::ReceiveTimeoutError) # already logged in monitorUpdatesInitial or monitorUpdatesSince
+        logger.error "******* #{herr.class}"
+        logger.error herr.to_s
+        logger.error herr.backtrace.join("\n") unless herr.kind_of?(HTTPClient::ReceiveTimeoutError) # already logged in monitorUpdatesInitial or monitorUpdatesSince
         raise herr
       end
     ensure
       if @filterSpecRef && isAlive?
-        $vim_log.info "#{log_prefix}: calling destroyPropertyFilter...Starting"
+        logger.info "#{log_prefix}: calling destroyPropertyFilter...Starting"
         destroyPropertyFilter(@filterSpecRef)
-        $vim_log.info "#{log_prefix}: calling destroyPropertyFilter...Complete"
+        logger.info "#{log_prefix}: calling destroyPropertyFilter...Complete"
       end
       @filterSpecRef = nil
       # @umPropCol     = nil
@@ -137,18 +137,18 @@ module MiqVimUpdate
   def stopUpdateMonitor
     log_prefix = "MiqVimUpdate.stopUpdateMonitor (#{@connId})"
 
-    $vim_log.info "#{log_prefix}: for address=<#{@server}>, username=<#{@username}>...Starting"
+    logger.info "#{log_prefix}: for address=<#{@server}>, username=<#{@username}>...Starting"
     @monitor = false
     if @umPropCol
       if isAlive?
-        $vim_log.info "#{log_prefix}: calling cancelWaitForUpdates...Starting"
+        logger.info "#{log_prefix}: calling cancelWaitForUpdates...Starting"
         cancelWaitForUpdates(@umPropCol)
-        $vim_log.info "#{log_prefix}: calling cancelWaitForUpdates...Complete"
+        logger.info "#{log_prefix}: calling cancelWaitForUpdates...Complete"
       end
       @umPropCol = nil
       @updateThread.run if @updateThread.status == "sleep"
     end
-    $vim_log.info "#{log_prefix}: for address=<#{@server}>, username=<#{@username}>...Complete"
+    logger.info "#{log_prefix}: for address=<#{@server}>, username=<#{@username}>...Complete"
   end
 
   def forceFail
@@ -159,7 +159,7 @@ module MiqVimUpdate
   def updateObject(objUpdate, initialUpdate = false)
     unless @inventoryHash # no cache to update
       return unless initialUpdate
-      $vim_log.info "MiqVimUpdate.updateObject: setting @inventoryHash to empty hash"
+      logger.info "MiqVimUpdate.updateObject: setting @inventoryHash to empty hash"
       @inventoryHash = {}
     end
 
@@ -171,12 +171,12 @@ module MiqVimUpdate
     when 'modify'
       updateProps(objUpdate, initialUpdate)
     else
-      $vim_log.warn "MiqVimUpdate.updateObject (#{@connId}): unrecognized operation: #{objUpdate.kind}"
+      logger.warn "MiqVimUpdate.updateObject (#{@connId}): unrecognized operation: #{objUpdate.kind}"
     end
   end
 
   def updateProps(objUpdate, initialUpdate = false)
-    $vim_log.debug "Update object (#{@connId}): #{objUpdate.obj.vimType}: #{objUpdate.obj}" if @debugUpdates
+    logger.debug "Update object (#{@connId}): #{objUpdate.obj.vimType}: #{objUpdate.obj}" if @debugUpdates
     return if !objUpdate.changeSet || objUpdate.changeSet.empty?
 
     #
@@ -191,7 +191,7 @@ module MiqVimUpdate
     hashName = "#{pm[:baseName]}ByMor"
     return unless (objHash = instance_variable_get(hashName)) # no cache to update
     unless (obj = objHash[objUpdate.obj])
-      $vim_log.warn "updateProps (#{@connId}): object #{objUpdate.obj} not found in #{hashName}"
+      logger.warn "updateProps (#{@connId}): object #{objUpdate.obj} not found in #{hashName}"
       return
     end
 
@@ -234,8 +234,8 @@ module MiqVimUpdate
       # Call the notify callback if enabled, defined and we are past the initial update
       #
       if @notifyMethod && !initialUpdate
-        $vim_log.debug "MiqVimUpdate.updateProps (#{@connId}): server = #{@server}, mor = (#{objUpdate.obj.vimType}, #{objUpdate.obj})"
-        $vim_log.debug "MiqVimUpdate.updateProps (#{@connId}): changedProps = [ #{changedProps.join(', ')} ]"
+        logger.debug "MiqVimUpdate.updateProps (#{@connId}): server = #{@server}, mor = (#{objUpdate.obj.vimType}, #{objUpdate.obj})"
+        logger.debug "MiqVimUpdate.updateProps (#{@connId}): changedProps = [ #{changedProps.join(', ')} ]"
         Thread.new do
           @notifyMethod.call(:server       => @server,
                              :username     => @username,
@@ -251,9 +251,9 @@ module MiqVimUpdate
       end
 
     rescue => err
-      $vim_log.warn "MiqVimUpdate::updateProps (#{@connId}): #{err}"
-      $vim_log.warn "Clearing cache for (#{@connId}): #{pm[:baseName]}"
-      $vim_log.debug err.backtrace.join("\n")
+      logger.warn "MiqVimUpdate::updateProps (#{@connId}): #{err}"
+      logger.warn "Clearing cache for (#{@connId}): #{pm[:baseName]}"
+      logger.debug err.backtrace.join("\n")
       dumpCache("#{pm[:baseName]}ByMor")
 
       instance_variable_set("#{pm[:baseName]}ByMor", nil)
@@ -266,9 +266,9 @@ module MiqVimUpdate
     objBaseType = objUpdate.obj.vimBaseType
 
     # always log additions to the inventory.
-    $vim_log.info "MiqVimUpdate.addObject (#{@connId}): #{objType}: #{objUpdate.obj}"
+    logger.info "MiqVimUpdate.addObject (#{@connId}): #{objType}: #{objUpdate.obj}"
     return unless (pm = @propMap[objBaseType.to_sym])  # not an object type we cache
-    $vim_log.info "MiqVimUpdate.addObject (#{@connId}): Adding object #{objType}: #{objUpdate.obj}"
+    logger.info "MiqVimUpdate.addObject (#{@connId}): Adding object #{objType}: #{objUpdate.obj}"
 
     #
     # First, add the object's MOR to the @inventoryHash entry for the object's type.
@@ -283,7 +283,7 @@ module MiqVimUpdate
       hashName = "#{pm[:baseName]}ByMor"
       unless instance_variable_get(hashName) # no cache to update
         return unless initialUpdate
-        $vim_log.info "MiqVimUpdate.addObject: setting #{hashName} and #{pm[:baseName]} to empty hash"
+        logger.info "MiqVimUpdate.addObject: setting #{hashName} and #{pm[:baseName]} to empty hash"
         instance_variable_set(hashName, {})
         instance_variable_set(pm[:baseName], {})
       end
@@ -298,7 +298,7 @@ module MiqVimUpdate
       # Call the notify callback if enabled, defined and we are past the initial update
       #
       if @notifyMethod && !initialUpdate
-        $vim_log.debug "MiqVimUpdate.addObject: server = #{@server}, mor = (#{objUpdate.obj.vimType}, #{objUpdate.obj})"
+        logger.debug "MiqVimUpdate.addObject: server = #{@server}, mor = (#{objUpdate.obj.vimType}, #{objUpdate.obj})"
         Thread.new do
           @notifyMethod.call(:server   => @server,
                              :username => @username,
@@ -310,9 +310,9 @@ module MiqVimUpdate
       end
 
     rescue => err
-      $vim_log.warn "MiqVimUpdate::addObject: #{err}"
-      $vim_log.warn "Clearing cache for: #{pm[:baseName]}"
-      $vim_log.debug err.backtrace.join("\n")
+      logger.warn "MiqVimUpdate::addObject: #{err}"
+      logger.warn "Clearing cache for: #{pm[:baseName]}"
+      logger.debug err.backtrace.join("\n")
       dumpCache("#{pm[:baseName]}ByMor")
 
       instance_variable_set("#{pm[:baseName]}ByMor", nil)
@@ -325,9 +325,9 @@ module MiqVimUpdate
     objBaseType = objUpdate.obj.vimBaseType
 
     # always log deletions from the inventory.
-    $vim_log.info "MiqVimUpdate.deleteObject (#{@connId}): #{objType}: #{objUpdate.obj}"
+    logger.info "MiqVimUpdate.deleteObject (#{@connId}): #{objType}: #{objUpdate.obj}"
     return unless (pm = @propMap[objBaseType.to_sym])      # not an object type we cache
-    $vim_log.info "MiqVimUpdate.deleteObject (#{@connId}): Deleting object: #{objType}: #{objUpdate.obj}"
+    logger.info "MiqVimUpdate.deleteObject (#{@connId}): Deleting object: #{objType}: #{objUpdate.obj}"
 
     ia = @inventoryHash[objType]
     ia.delete(objUpdate.obj)
@@ -341,7 +341,7 @@ module MiqVimUpdate
       # Call the notify callback if enabled, defined and we are past the initial update
       #
       if @notifyMethod && !initialUpdate
-        $vim_log.debug "MiqVimUpdate.deleteObject: server = #{@server}, mor = (#{objUpdate.obj.vimType}, #{objUpdate.obj})"
+        logger.debug "MiqVimUpdate.deleteObject: server = #{@server}, mor = (#{objUpdate.obj.vimType}, #{objUpdate.obj})"
         Thread.new do
           @notifyMethod.call(:server   => @server,
                              :username => @username,
@@ -353,9 +353,9 @@ module MiqVimUpdate
       end
 
     rescue => err
-      $vim_log.warn "MiqVimUpdate::deleteObject: #{err}"
-      $vim_log.warn "Clearing cache for: #{pm[:baseName]}"
-      $vim_log.debug err.backtrace.join("\n")
+      logger.warn "MiqVimUpdate::deleteObject: #{err}"
+      logger.warn "Clearing cache for: #{pm[:baseName]}"
+      logger.debug err.backtrace.join("\n")
       dumpCache("#{pm[:baseName]}ByMor")
 
       instance_variable_set("#{pm[:baseName]}ByMor", nil)
@@ -367,17 +367,17 @@ module MiqVimUpdate
     changedProps = [] if returnChangedProps
     changeSet.each do |propChange|
       if @debugUpdates
-        $vim_log.debug "\tpropChange name (path): #{propChange.name}"
-        $vim_log.debug "\tpropChange op: #{propChange.op}"
-        $vim_log.debug "\tpropChange val (type): #{propChange.val.class}"
+        logger.debug "\tpropChange name (path): #{propChange.name}"
+        logger.debug "\tpropChange op: #{propChange.op}"
+        logger.debug "\tpropChange val (type): #{propChange.val.class}"
 
-        $vim_log.debug "\t*** propChange val START:"
+        logger.debug "\t*** propChange val START:"
         oGi = @globalIndent
         @globalIndent = "\t\t"
         dumpObj(propChange.val)
         @globalIndent = oGi
-        $vim_log.debug "\t*** propChange val END"
-        $vim_log.debug "\t***"
+        logger.debug "\t*** propChange val END"
+        logger.debug "\t***"
       end
 
       #
@@ -424,9 +424,9 @@ module MiqVimUpdate
 
   def dumpCache(cache)
     return unless @debugUpdates
-    $vim_log.debug "**** Dumping #{cache} cache"
+    logger.debug "**** Dumping #{cache} cache"
     dumbObj(instance_variable_get(cache))
-    $vim_log.debug "**** #{cache} dump end"
+    logger.debug "**** #{cache} dump end"
   end
   private :dumpCache
 

--- a/lib/VMwareWebService/MiqVimVdlMod.rb
+++ b/lib/VMwareWebService/MiqVimVdlMod.rb
@@ -5,9 +5,9 @@ module MiqVimVdlConnectionMod
   #
   def vdlConnection
     require 'VMwareWebService/VixDiskLib/VixDiskLib'
-    VixDiskLib.init(->(s) { $vim_log.info  "VMware(VixDiskLib): #{s}" },
-                    ->(s) { $vim_log.warn  "VMware(VixDiskLib): #{s}" },
-                    ->(s) { $vim_log.error "VMware(VixDiskLib): #{s}" })
+    VixDiskLib.init(->(s) { logger.info  "VMware(VixDiskLib): #{s}" },
+                    ->(s) { logger.warn  "VMware(VixDiskLib): #{s}" },
+                    ->(s) { logger.error "VMware(VixDiskLib): #{s}" })
     $log.info "MiqVimVdlConnectionMod.vdlConnection: server - #{@server}"
     VixDiskLib.connect(:serverName => server,
                        :port       => 902,
@@ -17,7 +17,7 @@ module MiqVimVdlConnectionMod
   end
 
   def closeVdlConnection(connection)
-    $vim_log.info "MiqVimMod.closeVdlConnection: #{connection.serverName}"
+    logger.info "MiqVimMod.closeVdlConnection: #{connection.serverName}"
     connection.disconnect
   end
 end # module MiqVimVdlConnectionMod
@@ -31,9 +31,9 @@ module MiqVimVdlVcConnectionMod
   def vdlVcConnection
     require 'VMwareWebService/VixDiskLib/VixDiskLib'
 
-    VixDiskLib.init(->(s) { $vim_log.info  "VMware(VixDiskLib): #{s}" },
-                    ->(s) { $vim_log.warn  "VMware(VixDiskLib): #{s}" },
-                    ->(s) { $vim_log.error "VMware(VixDiskLib): #{s}" })
+    VixDiskLib.init(->(s) { logger.info  "VMware(VixDiskLib): #{s}" },
+                    ->(s) { logger.warn  "VMware(VixDiskLib): #{s}" },
+                    ->(s) { logger.error "VMware(VixDiskLib): #{s}" })
 
     $log.info "MiqVimVdlVcConnectionMod.vdlVcConnection: server - #{invObj.server}"
     thumb_print = if invObj.isVirtualCenter?

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -6,11 +6,13 @@ require 'more_core_extensions/core_ext/hash'
 require 'active_support/core_ext/object/try'
 
 require 'VMwareWebService/exception'
+require 'VMwareWebService/logging'
 require 'VMwareWebService/MiqVimVdlMod'
 require 'VMwareWebService/esx_thumb_print'
 require 'VMwareWebService/vcenter_thumb_print'
 
 class MiqVimVm
+  include VMwareWebService::Logging
   include MiqVimVdlVcConnectionMod
 
   EVM_SNAPSHOT_NAME         = "EvmSnapshot".freeze # TODO: externalize - not VIM specific
@@ -91,53 +93,53 @@ class MiqVimVm
   #######################
 
   def start(wait = true)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: calling powerOnVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: calling powerOnVM_Task" if logger
     taskMor = @invObj.powerOnVM_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: returned from powerOnVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: returned from powerOnVM_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end # def start
 
   def stop(wait = true)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: calling powerOffVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: calling powerOffVM_Task" if logger
     taskMor = @invObj.powerOffVM_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: returned from powerOffVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: returned from powerOffVM_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end # def stop
 
   def suspend(wait = true)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: calling suspendVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: calling suspendVM_Task" if logger
     taskMor = @invObj.suspendVM_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: returned from suspendVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: returned from suspendVM_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end # def suspend
 
   def reset(wait = true)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: calling resetVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: calling resetVM_Task" if logger
     taskMor = @invObj.resetVM_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: returned from resetVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: returned from resetVM_Task" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def rebootGuest
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: calling rebootGuest" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: calling rebootGuest" if logger
     @invObj.rebootGuest(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: returned from rebootGuest" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: returned from rebootGuest" if logger
   end
 
   def shutdownGuest
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: calling shutdownGuest" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: calling shutdownGuest" if logger
     @invObj.shutdownGuest(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: returned from shutdownGuest" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: returned from shutdownGuest" if logger
   end
 
   def standbyGuest
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: calling standbyGuest" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: calling standbyGuest" if logger
     @invObj.standbyGuest(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: returned from standbyGuest" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: returned from standbyGuest" if logger
   end
 
   def powerState
@@ -167,18 +169,18 @@ class MiqVimVm
   ############################
 
   def markAsTemplate
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: calling markAsTemplate" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: calling markAsTemplate" if logger
     @invObj.markAsTemplate(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: returned from markAsTemplate" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: returned from markAsTemplate" if logger
   end
 
   def markAsVm(pool, host = nil)
     hmor = nil
     hmor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
     pmor = (pool.kind_of?(Hash) ? pool['MOR'] : pool)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: calling markAsVirtualMachine" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: calling markAsVirtualMachine" if logger
     @invObj.markAsVirtualMachine(@vmMor, pmor, hmor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: returned from markAsVirtualMachine" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: returned from markAsVirtualMachine" if logger
   end
 
   def template?
@@ -193,18 +195,18 @@ class MiqVimVm
     hmor = (host.kind_of?(Hash) ? host['MOR'] : host)
     pool = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: calling migrateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, priority=<#{priority.inspect}>, state=<#{state.inspect}>" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: calling migrateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, priority=<#{priority.inspect}>, state=<#{state.inspect}>" if logger
     taskMor = @invObj.migrateVM_Task(@vmMor, pool, hmor, priority, state)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: returned from migrateVM_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::migrate: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: returned from migrateVM_Task" if logger
+    logger.debug "MiqVimVm::migrate: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end
 
   def renameVM(newName)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: calling rename_Task, vm=<#{@vmMor.inspect}>, newName=<#{newName}>" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: calling rename_Task, vm=<#{@vmMor.inspect}>, newName=<#{newName}>" if logger
     task_mor = @invObj.rename_Task(@vmMor, newName)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: returned from rename_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::renameVM: taskMor = #{task_mor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: returned from rename_Task" if logger
+    logger.debug "MiqVimVm::renameVM: taskMor = #{task_mor}" if logger
     waitForTask(task_mor)
   end
 
@@ -222,26 +224,26 @@ class MiqVimVm
       rsl.transform    = transform      if transform
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: calling relocateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, datastore=<#{dsmor.inspect}>, priority=<#{priority.inspect}>" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: calling relocateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, datastore=<#{dsmor.inspect}>, priority=<#{priority.inspect}>" if logger
     taskMor = @invObj.relocateVM_Task(@vmMor, rspec, priority)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: returned from relocateVM_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::relocate: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: returned from relocateVM_Task" if logger
+    logger.debug "MiqVimVm::relocate: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end
 
   def cloneVM_raw(folder, name, spec, wait = true)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: calling cloneVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: calling cloneVM_Task" if logger
     taskMor = @invObj.cloneVM_Task(@vmMor, folder, name, spec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: returned from cloneVM_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::cloneVM_raw: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: returned from cloneVM_Task" if logger
+    logger.debug "MiqVimVm::cloneVM_raw: taskMor = #{taskMor}" if logger
 
     if wait
       rv = waitForTask(taskMor)
-      $vim_log.debug "MiqVimVm::cloneVM_raw: rv = #{rv}" if $vim_log
+      logger.debug "MiqVimVm::cloneVM_raw: rv = #{rv}" if logger
       return rv
     end
 
-    $vim_log.debug "MiqVimVm::cloneVM_raw - no wait: taskMor = #{taskMor}" if $vim_log
+    logger.debug "MiqVimVm::cloneVM_raw - no wait: taskMor = #{taskMor}" if logger
     taskMor
   end
 
@@ -287,15 +289,15 @@ class MiqVimVm
   # end
 
   def unregister
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: calling unregisterVM" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: calling unregisterVM" if logger
     @invObj.unregisterVM(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: returned from unregisterVM" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: returned from unregisterVM" if logger
   end
 
   def destroy
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: calling destroy_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: calling destroy_Task" if logger
     taskMor = @invObj.destroy_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: returned from destroy_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: returned from destroy_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -377,33 +379,33 @@ class MiqVimVm
   end
 
   def createSnapshot(name, desc, memory, quiesce, wait = true, free_space_percent = 100)
-    $vim_log.debug "MiqVimVm::createSnapshot(#{name}, #{desc}, #{memory}, #{quiesce})" if $vim_log
+    logger.debug "MiqVimVm::createSnapshot(#{name}, #{desc}, #{memory}, #{quiesce})" if logger
     cs = connectionState
     raise "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: VM is not connected, connectionState = #{cs}" if cs != "connected"
     snapshot_free_space_check('create', free_space_percent)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: calling createSnapshot_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: calling createSnapshot_Task" if logger
     taskMor = @invObj.createSnapshot_Task(@vmMor, name, desc, memory, quiesce)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: returned from createSnapshot_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::createSnapshot: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: returned from createSnapshot_Task" if logger
+    logger.debug "MiqVimVm::createSnapshot: taskMor = #{taskMor}" if logger
 
     if wait
       snMor = waitForTask(taskMor)
-      $vim_log.warn "MiqVimVm::createSnapshot: snMor = #{snMor}" if $vim_log
+      logger.warn "MiqVimVm::createSnapshot: snMor = #{snMor}" if logger
       return snMor
     end
 
-    $vim_log.debug "MiqVimVm::createSnapshot - no wait: taskMor = #{taskMor}" if $vim_log
+    logger.debug "MiqVimVm::createSnapshot - no wait: taskMor = #{taskMor}" if logger
     taskMor
   end # def createSnapshot
 
   def removeSnapshot(snMor, subTree = "false", wait = true, free_space_percent = 100)
-    $vim_log.warn "MiqVimVm::removeSnapshot(#{snMor}, #{subTree})" if $vim_log
+    logger.warn "MiqVimVm::removeSnapshot(#{snMor}, #{subTree})" if logger
     snMor = getSnapMor(snMor)
     snapshot_free_space_check('remove', free_space_percent)
-    $vim_log.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: calling removeSnapshot_Task: snMor [#{snMor}] subtree [#{subTree}]" if $vim_log
+    logger.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: calling removeSnapshot_Task: snMor [#{snMor}] subtree [#{subTree}]" if logger
     taskMor = @invObj.removeSnapshot_Task(snMor, subTree)
-    $vim_log.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: returned from removeSnapshot_Task: snMor [#{snMor}]" if $vim_log
-    $vim_log.debug "MiqVimVm::removeSnapshot: taskMor = #{taskMor}" if $vim_log
+    logger.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: returned from removeSnapshot_Task: snMor [#{snMor}]" if logger
+    logger.debug "MiqVimVm::removeSnapshot: taskMor = #{taskMor}" if logger
     return taskMor unless wait
     waitForTask(taskMor)
   end # def removeSnapshot
@@ -421,40 +423,40 @@ class MiqVimVm
   end # def removeSnapshotByDescription
 
   def removeAllSnapshots(free_space_percent = 100)
-    $vim_log.debug "MiqVimVm::removeAllSnapshots" if $vim_log
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: calling removeAllSnapshots_Task" if $vim_log
+    logger.debug "MiqVimVm::removeAllSnapshots" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: calling removeAllSnapshots_Task" if logger
     snapshot_free_space_check('remove_all', free_space_percent)
     taskMor = @invObj.removeAllSnapshots_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: returned from removeAllSnapshots_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::removeAllSnapshots: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: returned from removeAllSnapshots_Task" if logger
+    logger.debug "MiqVimVm::removeAllSnapshots: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end # def removeAllSnapshots
 
   def revertToSnapshot(snMor)
-    $vim_log.debug "MiqVimVm::revertToSnapshot(#{snMor})" if $vim_log
+    logger.debug "MiqVimVm::revertToSnapshot(#{snMor})" if logger
     snMor = getSnapMor(snMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: calling revertToSnapshot_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: calling revertToSnapshot_Task" if logger
     taskMor = @invObj.revertToSnapshot_Task(snMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: returned from revertToSnapshot_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::revertToSnapshot: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: returned from revertToSnapshot_Task" if logger
+    logger.debug "MiqVimVm::revertToSnapshot: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end # def revertToSnapshot
 
   def revertToCurrentSnapshot
-    $vim_log.debug "MiqVimVm::revertToCurrentSnapshot" if $vim_log
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: calling revertToCurrentSnapshot_Task" if $vim_log
+    logger.debug "MiqVimVm::revertToCurrentSnapshot" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: calling revertToCurrentSnapshot_Task" if logger
     taskMor = @invObj.revertToCurrentSnapshot_Task(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: returned from revertToCurrentSnapshot_Task" if $vim_log
-    $vim_log.debug "MiqVimVm::revertToCurrentSnapshot: taskMor = #{taskMor}" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: returned from revertToCurrentSnapshot_Task" if logger
+    logger.debug "MiqVimVm::revertToCurrentSnapshot: taskMor = #{taskMor}" if logger
     waitForTask(taskMor)
   end # def revertToCurrentSnapshot
 
   def renameSnapshot(snMor, name, desc)
-    $vim_log.debug "MiqVimVm::renameSnapshot(#{snMor}, #{name}, #{desc})" if $vim_log
+    logger.debug "MiqVimVm::renameSnapshot(#{snMor}, #{name}, #{desc})" if logger
     snMor = getSnapMor(snMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: calling renameSnapshot" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: calling renameSnapshot" if logger
     @invObj.renameSnapshot(snMor, name, desc)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: returned from renameSnapshot" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: returned from renameSnapshot" if logger
   end # def renameSnapshot
 
   def snapshot_free_space_check(action, free_space_percent = 100)
@@ -508,13 +510,13 @@ class MiqVimVm
 
   def getSnapMor(snMor)
     unless snMor.respond_to?(:vimType)
-      $vim_log.debug "MiqVimVm::getSnapMor converting #{snMor} to MOR" if $vim_log
+      logger.debug "MiqVimVm::getSnapMor converting #{snMor} to MOR" if logger
       @cacheLock.synchronize(:SH) do
         raise "getSnapMor: VM #{@dsPath} has no snapshots" unless (sni = snapshotInfo_locked(true))
         raise "getSnapMor: snapshot #{snMor} not found" unless (snObj = sni['ssMorHash'][snMor])
         snMor = snObj['snapshot']
       end
-      $vim_log.debug "MiqVimVm::getSnapMor new MOR: #{snMor}" if $vim_log
+      logger.debug "MiqVimVm::getSnapMor new MOR: #{snMor}" if logger
     end
     (snMor)
   end # def getSnapMor
@@ -609,9 +611,9 @@ class MiqVimVm
   end # def getCfg
 
   def reconfig(vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -630,9 +632,9 @@ class MiqVimVm
 
   def setMemory(memMB)
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") { |cs| cs.memoryMB = memMB }
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -642,9 +644,9 @@ class MiqVimVm
 
   def setNumCPUs(numCPUs)
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") { |cs| cs.numCPUs = numCPUs }
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -666,9 +668,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end # def connectDevice
 
@@ -704,9 +706,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -722,9 +724,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -802,9 +804,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end # def addDisk
 
@@ -819,8 +821,8 @@ class MiqVimVm
     raise "removeDiskByFile: false setting for deleteBacking not yet supported" if deleteBacking == false
     controllerKey, key = getDeviceKeysByBacking(backingFile)
     raise "removeDiskByFile: no virtual device associated with: #{backingFile}" unless key
-    $vim_log.debug "MiqVimVm::MiqVimVm: backingFile = #{backingFile}" if $vim_log
-    $vim_log.debug "MiqVimVm::MiqVimVm: controllerKey = #{controllerKey}, key = #{key}" if $vim_log
+    logger.debug "MiqVimVm::MiqVimVm: backingFile = #{backingFile}" if logger
+    logger.debug "MiqVimVm::MiqVimVm: controllerKey = #{controllerKey}, key = #{key}" if logger
 
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
       vmcs.deviceChange = VimArray.new("ArrayOfVirtualDeviceConfigSpec") do |vmcs_vca|
@@ -858,9 +860,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end # def removeDiskByFile
 
@@ -868,7 +870,7 @@ class MiqVimVm
     disk = getDeviceByBacking(backingFile)
     raise "resizeDisk: no virtual device associated with: #{backingFile}" unless disk
     raise "resizeDisk: cannot reduce the size of a disk" unless newSizeInKb >= Integer(disk.capacityInKB)
-    $vim_log.debug "MiqVimVm::resizeDisk: backingFile = #{backingFile} current size = #{device.capacityInKB} newSize = #{newSizeInKb} KB" if $vim_log
+    logger.debug "MiqVimVm::resizeDisk: backingFile = #{backingFile} current size = #{device.capacityInKB} newSize = #{newSizeInKb} KB" if logger
 
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
       vmcs.deviceChange = VimArray.new("ArrayOfVirtualDeviceConfigSpec") do |vmcs_vca|
@@ -886,9 +888,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
   end
 
@@ -1040,9 +1042,9 @@ class MiqVimVm
       else
         aSpec = @miqAlarmSpecDisabled
       end
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: calling createAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: calling createAlarm" if logger
       alarmMor = @invObj.createAlarm(alarmManager, @vmMor, aSpec)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: returned from createAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: returned from createAlarm" if logger
       @miqAlarmMor = alarmMor
     ensure
       @cacheLock.sync_unlock if unlock
@@ -1073,9 +1075,9 @@ class MiqVimVm
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: calling getAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: calling getAlarm" if logger
       alarms = @invObj.getAlarm(@sic.alarmManager, @vmMor)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: returned from getAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: returned from getAlarm" if logger
       alarms.each do |aMor|
         ap = @invObj.getMoProp(aMor, "info.name")
         next unless ap['info']['name'][MIQ_ALARM_PFX]
@@ -1104,27 +1106,27 @@ class MiqVimVm
   def disableMiqAlarm
     @cacheLock.synchronize(:SH) do
       raise "disableMiqAlarm: MiqAlarm not configured for VM #{@dsPath}" unless (aMor = getMiqAlarm_locked)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: calling reconfigureAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: calling reconfigureAlarm" if logger
       @invObj.reconfigureAlarm(aMor, @miqAlarmSpecDisabled)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: returned from reconfigureAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: returned from reconfigureAlarm" if logger
     end
   end
 
   def enableMiqAlarm
     @cacheLock.synchronize(:SH) do
       raise "enableMiqAlarm: MiqAlarm not configured for VM #{@dsPath}" unless (aMor = getMiqAlarm_locked)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: calling reconfigureAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: calling reconfigureAlarm" if logger
       @invObj.reconfigureAlarm(aMor, @miqAlarmSpecEnabled)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: returned from reconfigureAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: returned from reconfigureAlarm" if logger
     end
   end
 
   def removeMiqAlarm
     @cacheLock.synchronize(:SH) do
       return unless (aMor = getMiqAlarm_locked)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: calling removeAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: calling removeAlarm" if logger
       @invObj.removeAlarm(aMor)
-      $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: returned from removeAlarm" if $vim_log
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: returned from removeAlarm" if logger
       @miqAlarmMor = nil
     end
   end
@@ -1176,9 +1178,9 @@ class MiqVimVm
       end
     end
 
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: calling reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: calling reconfigVM_Task" if logger
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: returned from reconfigVM_Task" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: returned from reconfigVM_Task" if logger
     waitForTask(taskMor)
 
     @extraConfig = nil
@@ -1286,16 +1288,16 @@ class MiqVimVm
   end
 
   def acquireMksTicket
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: calling acquireMksTicket" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: calling acquireMksTicket" if logger
     rv = @invObj.acquireMksTicket(@vmMor)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: returned from acquireMksTicket" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: returned from acquireMksTicket" if logger
     (rv)
   end # def acquireMksTicket
 
   def acquireTicket(ticketType)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: calling acquireTicket" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: calling acquireTicket" if logger
     rv = @invObj.acquireTicket(@vmMor, ticketType)
-    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: returned from acquireTicket" if $vim_log
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: returned from acquireTicket" if logger
     (rv)
   end # def acquireTicket
 

--- a/lib/VMwareWebService/MiqVimVm.rb
+++ b/lib/VMwareWebService/MiqVimVm.rb
@@ -93,53 +93,53 @@ class MiqVimVm
   #######################
 
   def start(wait = true)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: calling powerOnVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: calling powerOnVM_Task"
     taskMor = @invObj.powerOnVM_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: returned from powerOnVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).start: returned from powerOnVM_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end # def start
 
   def stop(wait = true)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: calling powerOffVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: calling powerOffVM_Task"
     taskMor = @invObj.powerOffVM_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: returned from powerOffVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).stop: returned from powerOffVM_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end # def stop
 
   def suspend(wait = true)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: calling suspendVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: calling suspendVM_Task"
     taskMor = @invObj.suspendVM_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: returned from suspendVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: returned from suspendVM_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end # def suspend
 
   def reset(wait = true)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: calling resetVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: calling resetVM_Task"
     taskMor = @invObj.resetVM_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: returned from resetVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: returned from resetVM_Task"
     return taskMor unless wait
     waitForTask(taskMor)
   end
 
   def rebootGuest
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: calling rebootGuest" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: calling rebootGuest"
     @invObj.rebootGuest(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: returned from rebootGuest" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).rebootGuest: returned from rebootGuest"
   end
 
   def shutdownGuest
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: calling shutdownGuest" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: calling shutdownGuest"
     @invObj.shutdownGuest(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: returned from shutdownGuest" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).shutdownGuest: returned from shutdownGuest"
   end
 
   def standbyGuest
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: calling standbyGuest" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: calling standbyGuest"
     @invObj.standbyGuest(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: returned from standbyGuest" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).standbyGuest: returned from standbyGuest"
   end
 
   def powerState
@@ -169,18 +169,18 @@ class MiqVimVm
   ############################
 
   def markAsTemplate
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: calling markAsTemplate" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: calling markAsTemplate"
     @invObj.markAsTemplate(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: returned from markAsTemplate" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsTemplate: returned from markAsTemplate"
   end
 
   def markAsVm(pool, host = nil)
     hmor = nil
     hmor = (host.kind_of?(Hash) ? host['MOR'] : host) if host
     pmor = (pool.kind_of?(Hash) ? pool['MOR'] : pool)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: calling markAsVirtualMachine" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: calling markAsVirtualMachine"
     @invObj.markAsVirtualMachine(@vmMor, pmor, hmor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: returned from markAsVirtualMachine" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).markAsVm: returned from markAsVirtualMachine"
   end
 
   def template?
@@ -195,18 +195,18 @@ class MiqVimVm
     hmor = (host.kind_of?(Hash) ? host['MOR'] : host)
     pool = (pool.kind_of?(Hash) ? pool['MOR'] : pool) if pool
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: calling migrateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, priority=<#{priority.inspect}>, state=<#{state.inspect}>" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: calling migrateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, priority=<#{priority.inspect}>, state=<#{state.inspect}>"
     taskMor = @invObj.migrateVM_Task(@vmMor, pool, hmor, priority, state)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: returned from migrateVM_Task" if logger
-    logger.debug "MiqVimVm::migrate: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).migrate: returned from migrateVM_Task"
+    logger.debug "MiqVimVm::migrate: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end
 
   def renameVM(newName)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: calling rename_Task, vm=<#{@vmMor.inspect}>, newName=<#{newName}>" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: calling rename_Task, vm=<#{@vmMor.inspect}>, newName=<#{newName}>"
     task_mor = @invObj.rename_Task(@vmMor, newName)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: returned from rename_Task" if logger
-    logger.debug "MiqVimVm::renameVM: taskMor = #{task_mor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameVM: returned from rename_Task"
+    logger.debug "MiqVimVm::renameVM: taskMor = #{task_mor}"
     waitForTask(task_mor)
   end
 
@@ -224,26 +224,26 @@ class MiqVimVm
       rsl.transform    = transform      if transform
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: calling relocateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, datastore=<#{dsmor.inspect}>, priority=<#{priority.inspect}>" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: calling relocateVM_Task, vm=<#{@vmMor.inspect}>, host=<#{hmor.inspect}>, pool=<#{pool.inspect}>, datastore=<#{dsmor.inspect}>, priority=<#{priority.inspect}>"
     taskMor = @invObj.relocateVM_Task(@vmMor, rspec, priority)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: returned from relocateVM_Task" if logger
-    logger.debug "MiqVimVm::relocate: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).relocate: returned from relocateVM_Task"
+    logger.debug "MiqVimVm::relocate: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end
 
   def cloneVM_raw(folder, name, spec, wait = true)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: calling cloneVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: calling cloneVM_Task"
     taskMor = @invObj.cloneVM_Task(@vmMor, folder, name, spec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: returned from cloneVM_Task" if logger
-    logger.debug "MiqVimVm::cloneVM_raw: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).cloneVM_raw: returned from cloneVM_Task"
+    logger.debug "MiqVimVm::cloneVM_raw: taskMor = #{taskMor}"
 
     if wait
       rv = waitForTask(taskMor)
-      logger.debug "MiqVimVm::cloneVM_raw: rv = #{rv}" if logger
+      logger.debug "MiqVimVm::cloneVM_raw: rv = #{rv}"
       return rv
     end
 
-    logger.debug "MiqVimVm::cloneVM_raw - no wait: taskMor = #{taskMor}" if logger
+    logger.debug "MiqVimVm::cloneVM_raw - no wait: taskMor = #{taskMor}"
     taskMor
   end
 
@@ -289,15 +289,15 @@ class MiqVimVm
   # end
 
   def unregister
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: calling unregisterVM" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: calling unregisterVM"
     @invObj.unregisterVM(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: returned from unregisterVM" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).unregister: returned from unregisterVM"
   end
 
   def destroy
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: calling destroy_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: calling destroy_Task"
     taskMor = @invObj.destroy_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: returned from destroy_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).destroy: returned from destroy_Task"
     waitForTask(taskMor)
   end
 
@@ -379,33 +379,33 @@ class MiqVimVm
   end
 
   def createSnapshot(name, desc, memory, quiesce, wait = true, free_space_percent = 100)
-    logger.debug "MiqVimVm::createSnapshot(#{name}, #{desc}, #{memory}, #{quiesce})" if logger
+    logger.debug "MiqVimVm::createSnapshot(#{name}, #{desc}, #{memory}, #{quiesce})"
     cs = connectionState
     raise "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: VM is not connected, connectionState = #{cs}" if cs != "connected"
     snapshot_free_space_check('create', free_space_percent)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: calling createSnapshot_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: calling createSnapshot_Task"
     taskMor = @invObj.createSnapshot_Task(@vmMor, name, desc, memory, quiesce)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: returned from createSnapshot_Task" if logger
-    logger.debug "MiqVimVm::createSnapshot: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).createSnapshot: returned from createSnapshot_Task"
+    logger.debug "MiqVimVm::createSnapshot: taskMor = #{taskMor}"
 
     if wait
       snMor = waitForTask(taskMor)
-      logger.warn "MiqVimVm::createSnapshot: snMor = #{snMor}" if logger
+      logger.warn "MiqVimVm::createSnapshot: snMor = #{snMor}"
       return snMor
     end
 
-    logger.debug "MiqVimVm::createSnapshot - no wait: taskMor = #{taskMor}" if logger
+    logger.debug "MiqVimVm::createSnapshot - no wait: taskMor = #{taskMor}"
     taskMor
   end # def createSnapshot
 
   def removeSnapshot(snMor, subTree = "false", wait = true, free_space_percent = 100)
-    logger.warn "MiqVimVm::removeSnapshot(#{snMor}, #{subTree})" if logger
+    logger.warn "MiqVimVm::removeSnapshot(#{snMor}, #{subTree})"
     snMor = getSnapMor(snMor)
     snapshot_free_space_check('remove', free_space_percent)
-    logger.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: calling removeSnapshot_Task: snMor [#{snMor}] subtree [#{subTree}]" if logger
+    logger.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: calling removeSnapshot_Task: snMor [#{snMor}] subtree [#{subTree}]"
     taskMor = @invObj.removeSnapshot_Task(snMor, subTree)
-    logger.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: returned from removeSnapshot_Task: snMor [#{snMor}]" if logger
-    logger.debug "MiqVimVm::removeSnapshot: taskMor = #{taskMor}" if logger
+    logger.warn "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeSnapshot: returned from removeSnapshot_Task: snMor [#{snMor}]"
+    logger.debug "MiqVimVm::removeSnapshot: taskMor = #{taskMor}"
     return taskMor unless wait
     waitForTask(taskMor)
   end # def removeSnapshot
@@ -423,40 +423,40 @@ class MiqVimVm
   end # def removeSnapshotByDescription
 
   def removeAllSnapshots(free_space_percent = 100)
-    logger.debug "MiqVimVm::removeAllSnapshots" if logger
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: calling removeAllSnapshots_Task" if logger
+    logger.debug "MiqVimVm::removeAllSnapshots"
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: calling removeAllSnapshots_Task"
     snapshot_free_space_check('remove_all', free_space_percent)
     taskMor = @invObj.removeAllSnapshots_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: returned from removeAllSnapshots_Task" if logger
-    logger.debug "MiqVimVm::removeAllSnapshots: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeAllSnapshots: returned from removeAllSnapshots_Task"
+    logger.debug "MiqVimVm::removeAllSnapshots: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end # def removeAllSnapshots
 
   def revertToSnapshot(snMor)
-    logger.debug "MiqVimVm::revertToSnapshot(#{snMor})" if logger
+    logger.debug "MiqVimVm::revertToSnapshot(#{snMor})"
     snMor = getSnapMor(snMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: calling revertToSnapshot_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: calling revertToSnapshot_Task"
     taskMor = @invObj.revertToSnapshot_Task(snMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: returned from revertToSnapshot_Task" if logger
-    logger.debug "MiqVimVm::revertToSnapshot: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToSnapshot: returned from revertToSnapshot_Task"
+    logger.debug "MiqVimVm::revertToSnapshot: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end # def revertToSnapshot
 
   def revertToCurrentSnapshot
-    logger.debug "MiqVimVm::revertToCurrentSnapshot" if logger
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: calling revertToCurrentSnapshot_Task" if logger
+    logger.debug "MiqVimVm::revertToCurrentSnapshot"
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: calling revertToCurrentSnapshot_Task"
     taskMor = @invObj.revertToCurrentSnapshot_Task(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: returned from revertToCurrentSnapshot_Task" if logger
-    logger.debug "MiqVimVm::revertToCurrentSnapshot: taskMor = #{taskMor}" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).revertToCurrentSnapshot: returned from revertToCurrentSnapshot_Task"
+    logger.debug "MiqVimVm::revertToCurrentSnapshot: taskMor = #{taskMor}"
     waitForTask(taskMor)
   end # def revertToCurrentSnapshot
 
   def renameSnapshot(snMor, name, desc)
-    logger.debug "MiqVimVm::renameSnapshot(#{snMor}, #{name}, #{desc})" if logger
+    logger.debug "MiqVimVm::renameSnapshot(#{snMor}, #{name}, #{desc})"
     snMor = getSnapMor(snMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: calling renameSnapshot" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: calling renameSnapshot"
     @invObj.renameSnapshot(snMor, name, desc)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: returned from renameSnapshot" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).renameSnapshot: returned from renameSnapshot"
   end # def renameSnapshot
 
   def snapshot_free_space_check(action, free_space_percent = 100)
@@ -510,13 +510,13 @@ class MiqVimVm
 
   def getSnapMor(snMor)
     unless snMor.respond_to?(:vimType)
-      logger.debug "MiqVimVm::getSnapMor converting #{snMor} to MOR" if logger
+      logger.debug "MiqVimVm::getSnapMor converting #{snMor} to MOR"
       @cacheLock.synchronize(:SH) do
         raise "getSnapMor: VM #{@dsPath} has no snapshots" unless (sni = snapshotInfo_locked(true))
         raise "getSnapMor: snapshot #{snMor} not found" unless (snObj = sni['ssMorHash'][snMor])
         snMor = snObj['snapshot']
       end
-      logger.debug "MiqVimVm::getSnapMor new MOR: #{snMor}" if logger
+      logger.debug "MiqVimVm::getSnapMor new MOR: #{snMor}"
     end
     (snMor)
   end # def getSnapMor
@@ -611,9 +611,9 @@ class MiqVimVm
   end # def getCfg
 
   def reconfig(vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reconfig: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end
 
@@ -632,9 +632,9 @@ class MiqVimVm
 
   def setMemory(memMB)
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") { |cs| cs.memoryMB = memMB }
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setMemory: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end
 
@@ -644,9 +644,9 @@ class MiqVimVm
 
   def setNumCPUs(numCPUs)
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") { |cs| cs.numCPUs = numCPUs }
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setNumCPUs: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end
 
@@ -668,9 +668,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).connectDevice: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end # def connectDevice
 
@@ -706,9 +706,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).attachIsoToCd: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end
 
@@ -724,9 +724,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resetCd: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end
 
@@ -804,9 +804,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addDisk: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end # def addDisk
 
@@ -821,8 +821,8 @@ class MiqVimVm
     raise "removeDiskByFile: false setting for deleteBacking not yet supported" if deleteBacking == false
     controllerKey, key = getDeviceKeysByBacking(backingFile)
     raise "removeDiskByFile: no virtual device associated with: #{backingFile}" unless key
-    logger.debug "MiqVimVm::MiqVimVm: backingFile = #{backingFile}" if logger
-    logger.debug "MiqVimVm::MiqVimVm: controllerKey = #{controllerKey}, key = #{key}" if logger
+    logger.debug "MiqVimVm::MiqVimVm: backingFile = #{backingFile}"
+    logger.debug "MiqVimVm::MiqVimVm: controllerKey = #{controllerKey}, key = #{key}"
 
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
       vmcs.deviceChange = VimArray.new("ArrayOfVirtualDeviceConfigSpec") do |vmcs_vca|
@@ -860,9 +860,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeDiskByFile: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end # def removeDiskByFile
 
@@ -870,7 +870,7 @@ class MiqVimVm
     disk = getDeviceByBacking(backingFile)
     raise "resizeDisk: no virtual device associated with: #{backingFile}" unless disk
     raise "resizeDisk: cannot reduce the size of a disk" unless newSizeInKb >= Integer(disk.capacityInKB)
-    logger.debug "MiqVimVm::resizeDisk: backingFile = #{backingFile} current size = #{device.capacityInKB} newSize = #{newSizeInKb} KB" if logger
+    logger.debug "MiqVimVm::resizeDisk: backingFile = #{backingFile} current size = #{device.capacityInKB} newSize = #{newSizeInKb} KB"
 
     vmConfigSpec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
       vmcs.deviceChange = VimArray.new("ArrayOfVirtualDeviceConfigSpec") do |vmcs_vca|
@@ -888,9 +888,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).resizeDisk: returned from reconfigVM_Task"
     waitForTask(taskMor)
   end
 
@@ -1042,9 +1042,9 @@ class MiqVimVm
       else
         aSpec = @miqAlarmSpecDisabled
       end
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: calling createAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: calling createAlarm"
       alarmMor = @invObj.createAlarm(alarmManager, @vmMor, aSpec)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: returned from createAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).addMiqAlarm_locked: returned from createAlarm"
       @miqAlarmMor = alarmMor
     ensure
       @cacheLock.sync_unlock if unlock
@@ -1075,9 +1075,9 @@ class MiqVimVm
     begin
       @cacheLock.sync_lock(:EX) if (unlock = @cacheLock.sync_shared?)
 
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: calling getAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: calling getAlarm"
       alarms = @invObj.getAlarm(@sic.alarmManager, @vmMor)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: returned from getAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).getMiqAlarm_locked: returned from getAlarm"
       alarms.each do |aMor|
         ap = @invObj.getMoProp(aMor, "info.name")
         next unless ap['info']['name'][MIQ_ALARM_PFX]
@@ -1106,27 +1106,27 @@ class MiqVimVm
   def disableMiqAlarm
     @cacheLock.synchronize(:SH) do
       raise "disableMiqAlarm: MiqAlarm not configured for VM #{@dsPath}" unless (aMor = getMiqAlarm_locked)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: calling reconfigureAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: calling reconfigureAlarm"
       @invObj.reconfigureAlarm(aMor, @miqAlarmSpecDisabled)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: returned from reconfigureAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).disableMiqAlarm: returned from reconfigureAlarm"
     end
   end
 
   def enableMiqAlarm
     @cacheLock.synchronize(:SH) do
       raise "enableMiqAlarm: MiqAlarm not configured for VM #{@dsPath}" unless (aMor = getMiqAlarm_locked)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: calling reconfigureAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: calling reconfigureAlarm"
       @invObj.reconfigureAlarm(aMor, @miqAlarmSpecEnabled)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: returned from reconfigureAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).enableMiqAlarm: returned from reconfigureAlarm"
     end
   end
 
   def removeMiqAlarm
     @cacheLock.synchronize(:SH) do
       return unless (aMor = getMiqAlarm_locked)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: calling removeAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: calling removeAlarm"
       @invObj.removeAlarm(aMor)
-      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: returned from removeAlarm" if logger
+      logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).removeMiqAlarm: returned from removeAlarm"
       @miqAlarmMor = nil
     end
   end
@@ -1178,9 +1178,9 @@ class MiqVimVm
       end
     end
 
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: calling reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: calling reconfigVM_Task"
     taskMor = @invObj.reconfigVM_Task(@vmMor, vmConfigSpec)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: returned from reconfigVM_Task" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).setExtraConfigAttributes: returned from reconfigVM_Task"
     waitForTask(taskMor)
 
     @extraConfig = nil
@@ -1288,16 +1288,16 @@ class MiqVimVm
   end
 
   def acquireMksTicket
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: calling acquireMksTicket" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: calling acquireMksTicket"
     rv = @invObj.acquireMksTicket(@vmMor)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: returned from acquireMksTicket" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireMksTicket: returned from acquireMksTicket"
     (rv)
   end # def acquireMksTicket
 
   def acquireTicket(ticketType)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: calling acquireTicket" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: calling acquireTicket"
     rv = @invObj.acquireTicket(@vmMor, ticketType)
-    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: returned from acquireTicket" if logger
+    logger.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: returned from acquireTicket"
     (rv)
   end # def acquireTicket
 

--- a/lib/VMwareWebService/VimService.rb
+++ b/lib/VMwareWebService/VimService.rb
@@ -1,8 +1,11 @@
 require "handsoap"
 require 'active_support/core_ext/numeric/bytes'
+require 'VMwareWebService/logging'
 require 'VMwareWebService/VimTypes'
 
 class VimService < Handsoap::Service
+  include VMwareWebService::Logging
+
   attr_reader :sic, :about, :apiVersion, :isVirtualCenter, :v20, :v2, :v4, :v5, :v6, :serviceInstanceMor, :session_cookie
 
   Handsoap.http_driver = :HTTPClient
@@ -1291,14 +1294,14 @@ class VimService < Handsoap::Service
       if @xml_payload_len > @xml_payload_max
         @xml_payload_len = 0
 
-        $vim_log.debug("#{log_prefix} Running garbage collection")
+        logger.debug("#{log_prefix} Running garbage collection")
 
         # Force a GC, because Ruby's GC is triggered on number of objects without
         #   regard to size.  The object we just freed may not be released right away.
         gc_time = Benchmark.realtime { GC.start }
 
         gc_log_level = gc_time >= 5 ? :warn : :debug
-        $vim_log.send(gc_log_level, "#{log_prefix} Garbage collection took #{gc_time} seconds")
+        logger.send(gc_log_level, "#{log_prefix} Garbage collection took #{gc_time} seconds")
       end
     end
   end

--- a/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb
+++ b/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb
@@ -70,12 +70,12 @@ class VixDiskLib
       i = 0
       @drb_services.each do |vdl_service|
         i += 1
-        logger.info "VixDiskLib.exit: shutting down service #{i} of #{@drb_services.size}" if logger
+        logger.info "VixDiskLib.exit: shutting down service #{i} of #{@drb_services.size}"
         unless vdl_service.nil?
           begin
             vdl_service.shutdown = true
           rescue DRb::DRbConnError
-            logger.info "VixDiskLib.exit: DRb connection closed due to service shutdown.  Continuing" if logger
+            logger.info "VixDiskLib.exit: DRb connection closed due to service shutdown.  Continuing"
           end
         end
       end
@@ -126,7 +126,7 @@ class VixDiskLib
     uri_writer.close
     proc_reader.close
     Process.detach(pid)
-    logger.info "VixDiskLibServer Process #{pid} started" if logger
+    logger.info "VixDiskLibServer Process #{pid} started"
     DRb.start_service
     retry_num = 5
     uri       = get_uri(uri_reader)

--- a/lib/VMwareWebService/VixDiskLib/vdl_wrapper.rb
+++ b/lib/VMwareWebService/VixDiskLib/vdl_wrapper.rb
@@ -4,7 +4,7 @@ require 'ffi-vix_disk_lib/api_wrapper'
 require 'VMwareWebService/VimTypes'
 require 'time'
 
-$vim_log = Logger.new $stdout
+$logger = Logger.new $stdout
 
 VixDiskLibApi = FFI::VixDiskLib::ApiWrapper
 class VdlWrapper
@@ -20,9 +20,9 @@ class VdlWrapper
     @vddk = server
   end
 
-  @info_log  = ->(s) { $vim_log.info "VMware(VixDiskLib): #{s}" }
-  @warn_log  = ->(s) { $vim_log.warn "VMware(VixDiskLib): #{s}" }
-  @error_log = ->(s) { $vim_log.error "VMware(VixDiskLib): #{s}" }
+  @info_log  = ->(s) { $logger.info "VMware(VixDiskLib): #{s}" }
+  @warn_log  = ->(s) { $logger.warn "VMware(VixDiskLib): #{s}" }
+  @error_log = ->(s) { $logger.error "VMware(VixDiskLib): #{s}" }
 
   def self.init
     return if @initialized
@@ -32,10 +32,10 @@ class VdlWrapper
   end
 
   def self.dumpDisks(server_name)
-    $vim_log.warn "*** Open VdlDisks for server #{server_name}" if $vim_log
+    $logger.warn "*** Open VdlDisks for server #{server_name}" if $logger
     @connection.dumpDisks unless @connection.nil? || @connection.serverName != server_name
     @vddk.running = true
-    $vim_log.warn "*** Open VdlDisks end" if $vim_log
+    $logger.warn "*** Open VdlDisks end" if $logger
   end
 
   def self.inc_server_disk_count
@@ -51,7 +51,7 @@ class VdlWrapper
   end
 
   def self.connect(connect_parms)
-    $vim_log.info "VdlWrapper.connect: #{connect_parms[:server_name]}" if $vim_log
+    $logger.info "VdlWrapper.connect: #{connect_parms[:server_name]}" if $logger
     raise VixDiskLibError, "VixDiskLib is not initialized" unless @initialized
     raise VixDiskLibError, "Already connected to #{@connection.serverName}" if @connection
     @connection = VdlConnection.new(connect_parms, @vddk)
@@ -59,7 +59,7 @@ class VdlWrapper
   end
 
   def self.__disconnect__(conn_obj)
-    $vim_log.info "VdlWrapper.__disconnect__: #{conn_obj.serverName}" if $vim_log
+    $logger.info "VdlWrapper.__disconnect__: #{conn_obj.serverName}" if $logger
     raise VixDiskLibError, "VixDiskLib is not initialized" unless @initialized
     FFI::VixDiskLib::API.disconnect(conn_obj.vdl_connection)
     @connection = nil
@@ -74,7 +74,7 @@ class VdlWrapper
     # the DRb service (this process) to segfault during the exit sequence.
     #
     # super
-    $vim_log.info "VixDiskLib has exited cleanly"
+    $logger.info "VixDiskLib has exited cleanly"
     @vddk.running = true
     @vddk.shutdown = true
     @initialized = nil
@@ -90,7 +90,7 @@ class VdlConnection
 
   def initialize(connect_parms, vddk)
     @serverName     = connect_parms[:server_name]
-    $vim_log.info "VdlConnection.initialize: #{@serverName}" if $vim_log
+    $logger.info "VdlConnection.initialize: #{@serverName}" if $logger
     @vdl_connection  = VixDiskLibApi.connect(connect_parms)
     @disks           = []
     @disk_lock       = Sync.new
@@ -98,10 +98,10 @@ class VdlConnection
   end
 
   def disconnect
-    $vim_log.info "VdlConnection.disconnect: #{@serverName}" if $vim_log
+    $logger.info "VdlConnection.disconnect: #{@serverName}" if $logger
     @disk_lock.synchronize(:EX) do
       if !@vdl_connection
-        $vim_log.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $vim_log
+        $logger.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $logger
       else
         __close_disks__
         VdlWrapper.__disconnect__(self)
@@ -117,7 +117,7 @@ class VdlConnection
     @vddk.running = true
     @disk_lock.sync_lock(:SH) if (unlock = !@disk_lock.sync_locked?)
     @disks.each do |d|
-      $vim_log.warn "    VdlDisk: #{d.path}, opened: #{d.timeStamp}" if $vim_log
+      $logger.warn "    VdlDisk: #{d.path}, opened: #{d.timeStamp}" if $logger
     end
   ensure
     @disk_lock.sync_unlock if unlock
@@ -130,11 +130,11 @@ class VdlConnection
       disk = VdlDisk.new(self, path, flags)
       @disks << disk
       nd = VdlWrapper.inc_server_disk_count
-      $vim_log.info "VdlConnection.getDisk: #{@serverName} open disks = #{nd}" if $vim_log
-      if nd >= MAX_DISK_WARN && $vim_log
-        $vim_log.warn "VdlConnection::getDisk: connection to server: #{@serverName}"
-        $vim_log.warn "VdlConnection::getDisk: number of open disks = #{nd}"
-        $vim_log.warn "VdlConnection::getDisk: subsequent open calls may fail"
+      $logger.info "VdlConnection.getDisk: #{@serverName} open disks = #{nd}" if $logger
+      if nd >= MAX_DISK_WARN && $logger
+        $logger.warn "VdlConnection::getDisk: connection to server: #{@serverName}"
+        $logger.warn "VdlConnection::getDisk: number of open disks = #{nd}"
+        $logger.warn "VdlConnection::getDisk: subsequent open calls may fail"
         VdlWrapper.dumpDisks(@serverName)
       end
       return disk
@@ -147,11 +147,11 @@ class VdlConnection
     @vddk.running = true
     VixDiskLibApi.close(diskObj.handle)
     if !@vdl_connection
-      $vim_log.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $vim_log
+      $logger.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $logger
     else
       @disks.delete(diskObj)
       nd = VdlWrapper.dec_server_disk_count
-      $vim_log.warn "VdlConnection.__close_disk__: #{@serverName} open disks = #{nd}" if $vim_log
+      $logger.warn "VdlConnection.__close_disk__: #{@serverName} open disks = #{nd}" if $logger
     end
   ensure
     @disk_lock.sync_unlock if unlock
@@ -161,7 +161,7 @@ class VdlConnection
     raise VixDiskLibError,
           "VdlConnection::__close_disks__: exclusive disk lock not held" unless @disk_lock.sync_exclusive?
     if !@vdl_connection
-      $vim_log.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $vim_log
+      $logger.warn "VDLConnection.disconnect: server: #{@serverName} not connected" if $logger
     else
       @disks.each(&:close)
     end
@@ -178,7 +178,7 @@ class VdlDisk
 
   def initialize(conn_obj, path, flags)
     @time_stamp = Time.now
-    $vim_log.debug "VdlDisk.new <#{object_id}>: opening #{path}" if $vim_log && $vim_log.debug?
+    $logger.debug "VdlDisk.new <#{object_id}>: opening #{path}" if $logger && $logger.debug?
     @connection = conn_obj
     @handle = VixDiskLibApi.open(@connection.vdl_connection, path, flags)
     @path = path
@@ -194,11 +194,11 @@ class VdlDisk
   end
 
   def close
-    $vim_log.debug "VdlDisk.close <#{ssId}>: closing #{@path}" if $vim_log && $vim_log.debug?
+    $logger.debug "VdlDisk.close <#{ssId}>: closing #{@path}" if $logger && $logger.debug?
     @vddk.running = true
     @handle_lock.synchronize(:EX) do
       if !@handle
-        $vim_log.debug "VdlDisk.close: #{@path} not open" if $vim_log && $vim_log.debug?
+        $logger.debug "VdlDisk.close: #{@path} not open" if $logger && $logger.debug?
       else
         @connection.__close_disk__(self)
         @handle = nil

--- a/lib/VMwareWebService/logging.rb
+++ b/lib/VMwareWebService/logging.rb
@@ -1,0 +1,17 @@
+require "logger"
+
+module VMwareWebService
+  class << self
+    attr_writter :logger
+  end
+
+  def self.logger
+    @logger ||= Logger.new(nil)
+  end
+
+  module Logging
+    def logger
+      VMwareWebService.logger
+    end
+  end
+end

--- a/lib/VMwareWebService/logging.rb
+++ b/lib/VMwareWebService/logging.rb
@@ -1,11 +1,10 @@
-require "logger"
-
 module VMwareWebService
   class << self
-    attr_writter :logger
+    attr_writer :logger
   end
 
   def self.logger
+    require "logger"
     @logger ||= Logger.new(nil)
   end
 

--- a/lib/vmware_web_service.rb
+++ b/lib/vmware_web_service.rb
@@ -5,3 +5,5 @@ autoload :VimArray,  'VMwareWebService/VimTypes'
 autoload :VimString, 'VMwareWebService/VimTypes'
 autoload :VimFault,  'VMwareWebService/VimTypes'
 autoload :VimClass,  'VMwareWebService/VimTypes'
+
+require "VMwareWebService/logging"

--- a/spec/VMwareWebService/MiqVimClientBase_spec.rb
+++ b/spec/VMwareWebService/MiqVimClientBase_spec.rb
@@ -2,13 +2,7 @@ require 'VMwareWebService/MiqVimClientBase'
 
 describe MiqVimClientBase do
   before do
-    @logger  = $vim_log
-    $vim_log = double.as_null_object
     allow_any_instance_of(described_class).to receive_messages(:retrieveServiceContent => double.as_null_object)
-  end
-
-  after do
-    $vim_log = @logger
   end
 
   context "#sdk_uri" do

--- a/test/VMwareWebService/MiqVimFolderTest.rb
+++ b/test/VMwareWebService/MiqVimFolderTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stderr.sync = true
 $stdout.sync = true

--- a/test/VMwareWebService/MiqVimPerfTest.rb
+++ b/test/VMwareWebService/MiqVimPerfTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # MiqVimClientBase.wiredump_file = "perf.txt"
 

--- a/test/VMwareWebService/MiqVimVmTest.rb
+++ b/test/VMwareWebService/MiqVimVmTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # TARGET_VM = "rpo-test2"
 TARGET_VM = "NetappDsTest2"

--- a/test/VMwareWebService/addDiskTest.rb
+++ b/test/VMwareWebService/addDiskTest.rb
@@ -6,8 +6,8 @@ unless ARGV.length == 1 && ARGV[0] =~ /(add|remove)/
   exit 1
 end
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 targetVm = raise "please define"
 targetVmPath = nil

--- a/test/VMwareWebService/addHostToCluster.rb
+++ b/test/VMwareWebService/addHostToCluster.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/test/VMwareWebService/addNasDatastoreByName.rb
+++ b/test/VMwareWebService/addNasDatastoreByName.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/test/VMwareWebService/addStandaloneHost.rb
+++ b/test/VMwareWebService/addStandaloneHost.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = ""

--- a/test/VMwareWebService/alarmManagerTest.rb
+++ b/test/VMwareWebService/alarmManagerTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $DEBUG = true
 

--- a/test/VMwareWebService/alarmTest.rb
+++ b/test/VMwareWebService/alarmTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 TARGET_VM = raise "please define"
 vim = MiqVim.new(SERVER, USERNAME, PASSWORD)

--- a/test/VMwareWebService/annotation.rb
+++ b/test/VMwareWebService/annotation.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/browserTest.rb
+++ b/test/VMwareWebService/browserTest.rb
@@ -4,8 +4,8 @@ require 'VMwareWebService/MiqVim'
 require 'fs/MiqFS/MiqFS'
 require 'fs/VimDatastoreFS/VimDatastoreFS'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/test/VMwareWebService/cloneAsyncTest.rb
+++ b/test/VMwareWebService/cloneAsyncTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/cloneCsmTest.rb
+++ b/test/VMwareWebService/cloneCsmTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/cloneDvsTest.rb
+++ b/test/VMwareWebService/cloneDvsTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/cloneTest.rb
+++ b/test/VMwareWebService/cloneTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/cpuAffinity.rb
+++ b/test/VMwareWebService/cpuAffinity.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/cpuMemTest.rb
+++ b/test/VMwareWebService/cpuMemTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 TARGET_VM = "rpo-test2"
 vmMor = nil

--- a/test/VMwareWebService/createFolderTest.rb
+++ b/test/VMwareWebService/createFolderTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 SERVER   = ""
 USERNAME = ""

--- a/test/VMwareWebService/createNfsDatastore.rb
+++ b/test/VMwareWebService/createNfsDatastore.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/test/VMwareWebService/customFieldsManagerTest.rb
+++ b/test/VMwareWebService/customFieldsManagerTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $DEBUG = true
 vim = MiqVim.new(SERVER, USERNAME, PASSWORD)

--- a/test/VMwareWebService/customizationSpecManagerTest.rb
+++ b/test/VMwareWebService/customizationSpecManagerTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = true
 

--- a/test/VMwareWebService/diskPerf.rb
+++ b/test/VMwareWebService/diskPerf.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 $stderr.sync = true

--- a/test/VMwareWebService/emsRefreshTest.rb
+++ b/test/VMwareWebService/emsRefreshTest.rb
@@ -16,7 +16,7 @@ VC_ACCESSORS = [
   [:resourcePoolsByMor, :rp],
 ]
 
-$vim_log = Logger.new("./ems_refresh_test.log") unless USE_BROKER
+VMwareWebService.logger = Logger.new("./ems_refresh_test.log") unless USE_BROKER
 
 begin
   loop do

--- a/test/VMwareWebService/enterMaintenanceMode.rb
+++ b/test/VMwareWebService/enterMaintenanceMode.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/test/VMwareWebService/eventHistoryTest.rb
+++ b/test/VMwareWebService/eventHistoryTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostAdvancedOptionTest.rb
+++ b/test/VMwareWebService/hostAdvancedOptionTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $DEBUG = true
 

--- a/test/VMwareWebService/hostConfigSpecTest.rb
+++ b/test/VMwareWebService/hostConfigSpecTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostDatastoreTest.rb
+++ b/test/VMwareWebService/hostDatastoreTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/test/VMwareWebService/hostDvsTest.rb
+++ b/test/VMwareWebService/hostDvsTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/hostFirewallTest.rb
+++ b/test/VMwareWebService/hostFirewallTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostNetworkTest.rb
+++ b/test/VMwareWebService/hostNetworkTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostServiceTest.rb
+++ b/test/VMwareWebService/hostServiceTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostSnmpSystemTest.rb
+++ b/test/VMwareWebService/hostSnmpSystemTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostStandByTest.rb
+++ b/test/VMwareWebService/hostStandByTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/test/VMwareWebService/hostStorageSystem.rb
+++ b/test/VMwareWebService/hostStorageSystem.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 $miq_wiredump = true

--- a/test/VMwareWebService/hostTest.rb
+++ b/test/VMwareWebService/hostTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/hostVirtualNicManagerTest.rb
+++ b/test/VMwareWebService/hostVirtualNicManagerTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/linkedCloneFromTemplateTest.rb
+++ b/test/VMwareWebService/linkedCloneFromTemplateTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/linkedCloneTest.rb
+++ b/test/VMwareWebService/linkedCloneTest.rb
@@ -2,8 +2,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/test/VMwareWebService/list_evm_snapshots.rb
+++ b/test/VMwareWebService/list_evm_snapshots.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 if ARGV.length != 3
   $stderr.puts "Usage: #{$0} server username password"

--- a/test/VMwareWebService/logTest.rb
+++ b/test/VMwareWebService/logTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $DEBUG = true
 $miq_wiredump = true

--- a/test/VMwareWebService/migrateTest.rb
+++ b/test/VMwareWebService/migrateTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 TARGET_VM = "rpo-test2"
 vmMor = nil

--- a/test/VMwareWebService/rebootHostTest.rb
+++ b/test/VMwareWebService/rebootHostTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/test/VMwareWebService/remoteDisplayVnc.rb
+++ b/test/VMwareWebService/remoteDisplayVnc.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/rm_evm_snapshots.rb
+++ b/test/VMwareWebService/rm_evm_snapshots.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 if ARGV.length != 3
   $stderr.puts "Usage: #{$0} server username password"

--- a/test/VMwareWebService/rtPerfTest.rb
+++ b/test/VMwareWebService/rtPerfTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 $stderr.sync = true

--- a/test/VMwareWebService/selectionSpecBrokerClassTest.rb
+++ b/test/VMwareWebService/selectionSpecBrokerClassTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/selectionSpecBrokerInstanceTest.rb
+++ b/test/VMwareWebService/selectionSpecBrokerInstanceTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/selectionSpecVimClassTest.rb
+++ b/test/VMwareWebService/selectionSpecVimClassTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/selectionSpecVimTest.rb
+++ b/test/VMwareWebService/selectionSpecVimTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VMwareWebService/shutdownHostTest.rb
+++ b/test/VMwareWebService/shutdownHostTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/test/VMwareWebService/snapshotTest.rb
+++ b/test/VMwareWebService/snapshotTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 

--- a/test/VMwareWebService/templateTest.rb
+++ b/test/VMwareWebService/templateTest.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 TARGET_VM = "rpo-template-test"
 vmMor = nil

--- a/test/VMwareWebService/thinProvisioned.rb
+++ b/test/VMwareWebService/thinProvisioned.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 TARGET_VM = raise "please define"
 miqVm = nil

--- a/test/VMwareWebService/vdlBrowserTest.rb
+++ b/test/VMwareWebService/vdlBrowserTest.rb
@@ -3,8 +3,8 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VixDiskLib/VixDiskLib'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stderr.sync = true
 $stdout.sync = true

--- a/test/VMwareWebService/vimEventMonitory.rb
+++ b/test/VMwareWebService/vimEventMonitory.rb
@@ -5,8 +5,8 @@ SERVER   = raise "please define SERVER"
 USERNAME = raise "please define USERNAME"
 PASSWORD = raise "please define PASSWORD"
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 vimEm = MiqVimEventMonitor.new(SERVER, USERNAME, PASSWORD)
 

--- a/test/VMwareWebService/vimInventory.rb
+++ b/test/VMwareWebService/vimInventory.rb
@@ -6,8 +6,8 @@ USERNAME = raise "please define USERNAME"
 PASSWORD = raise "please define PASSWORD"
 
 $stderr.sync = true
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump       = true
 vim = MiqVimInventory.new(SERVER, USERNAME, PASSWORD)

--- a/test/VMwareWebService/virtualApp.rb
+++ b/test/VMwareWebService/virtualApp.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/test/VMwareWebService/virtualDiskPerf.rb
+++ b/test/VMwareWebService/virtualDiskPerf.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 $stdout.sync = true
 $stderr.sync = true

--- a/test/VMwareWebService/vmsafe.rb
+++ b/test/VMwareWebService/vmsafe.rb
@@ -1,8 +1,8 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/test/VixDiskLib/api_test.rb
+++ b/test/VixDiskLib/api_test.rb
@@ -1,7 +1,7 @@
 require "ffi-vix_disk_lib/api_wrapper"
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 vmdk = "/vmfs/volumes/StarM1-Dev/Citrix-Mahwah2/Citrix-Mahwah2.vmdk"
 

--- a/test/VixDiskLib/cookedTest.rb
+++ b/test/VixDiskLib/cookedTest.rb
@@ -1,7 +1,7 @@
 require 'VMwareWebService/VixDiskLib/VixDiskLib'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 diskFiles = [
   "/vmfs/volumes/StarM2-LUN1/VMmini-101/VMmini-101.vmdk"

--- a/test/VixDiskLib/rawTest11.rb
+++ b/test/VixDiskLib/rawTest11.rb
@@ -1,8 +1,8 @@
 $:.push("#{File.dirname(__FILE__)}/..")
 require "VixDiskLib_raw"
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
 vmdk = "/vmfs/volumes/47dade33-4f4a4875-3951-00188b404015/rpo-test2/rpo-test2.vmdk"
 

--- a/test/VixDiskLib/vixDiskModTest.rb
+++ b/test/VixDiskLib/vixDiskModTest.rb
@@ -3,10 +3,10 @@ require 'fs/MiqFS/MiqFS'
 require 'VMwareWebService/VixDiskLib/VixDiskLib'
 require 'ostruct'
 
-$vim_log = Logger.new(STDOUT)
-$vim_log.level = Logger::WARN
+VMwareWebService.logger = Logger.new(STDOUT)
+VMwareWebService.logger.level = Logger::WARN
 
-$log = $vim_log
+$log = VMwareWebService.logger
 
 VixDiskLib.init
 


### PR DESCRIPTION
Replace the global `$vim_log` which is expected to be set-up by ManageIQ core with a gem logger able to be configured by the caller.