### PR TITLE
Drop ruby 2.5 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.5'
         - '2.6'
         - '2.7'
         rails-version:

--- a/vmware_web_service.gemspec
+++ b/vmware_web_service.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A ruby interface to Vmware Web Services SDK"
   spec.licenses    = ["Apache-2.0"]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
   spec.files = Dir["{app,config,lib}/**/*"]
 
   spec.add_dependency "activesupport",        ">= 5.2.4.3", "< 7.0"


### PR DESCRIPTION
Current versions of nokogiri require ruby 2.6 at a minimum.  Drop ruby 2.5 support.