### PR TITLE
Fix undefined method logger in VixDiskLib.connect

### DIFF
--- a/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb
+++ b/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb
@@ -100,7 +100,7 @@ class VixDiskLib
 
     my_env["LD_LIBRARY_PATH"] = (my_env["LD_LIBRARY_PATH"].to_s.split(':') << VIXDISKLIB_PATH).compact.join(":")
     raise VixDiskLibError, "VixDiskLib.connect() failed: No logger defined" unless logger
-    my_env["LOG_FILE"] = logger.logdev.filename.to_s if logger.logdev.kind_of?(Logger::LogDevice)
+    my_env["LOG_FILE"] = logger.logdev.filename.to_s if logger.try(:logdev).kind_of?(Logger::LogDevice)
 
     my_env
   end

--- a/lib/VMwareWebService/logging.rb
+++ b/lib/VMwareWebService/logging.rb
@@ -9,8 +9,16 @@ module VMwareWebService
   end
 
   module Logging
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def logger
+        VMwareWebService.logger
+      end
+    end
+
     def logger
-      VMwareWebService.logger
+      self.class.logger
     end
   end
 end


### PR DESCRIPTION
The VixDiskLib.connect method is a class-method and the `VMwareWebService::Logging` module only defined an instance method.

```
ERROR -- evm: Q-task_id([job_dispatcher]) Unable to mount filesystem.  Reason:[undefined local variable or method `logger' for VixDiskLib:Class] for VM [[88888-INFRA02-NFS4IO] 88888-egMGRtest-TUSA/88888-egMGRtest-TUSA.vmx]
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/vmware_web_service-3.1.0/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb:102:in `setup_env'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/vmware_web_service-3.1.0/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb:112:in `start_service'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/vmware_web_service-3.1.0/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb:43:in `block in connect'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/sync-0.5.0/lib/sync.rb:230:in `block in sync_synchronize'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/sync-0.5.0/lib/sync.rb:227:in `handle_interrupt'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/sync-0.5.0/lib/sync.rb:227:in `sync_synchronize'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/vmware_web_service-3.1.0/lib/VMwareWebService/VixDiskLib/VixDiskLib.rb:40:in `connect'
ERROR -- evm: Q-task_id([job_dispatcher]) MIQExtract.new /opt/manageiq/manageiq-gemset/gems/vmware_web_service-3.1.0/lib/VMwareWebService/MiqVimVdlMod.rb:46:in `vdlVcConnection'
```

This was easy to reproduce by running:
```
vc = ManageIQ::Providers::Vmware::InfraManager.first
vm = vc.vms.first
vm.provider_object.vdlVcConnection
```

https://github.com/ManageIQ/manageiq-providers-vmware/issues/858