### PR TITLE
Update ruby versions used to run CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.6'
         - '2.7'
+        - '3.0'
         rails-version:
         - '6.0'
         - '6.1'

--- a/lib/VMwareWebService/MiqVimDataStore.rb
+++ b/lib/VMwareWebService/MiqVimDataStore.rb
@@ -317,6 +317,6 @@ class MiqVimDataStore
   end
 
   def encode_path_url(path)
-    URI.encode(path, /[^#{URI::PATTERN::UNRESERVED}]/)
+    URI::DEFAULT_PARSER.escape(path, /[^#{URI::PATTERN::UNRESERVED}]/o)
   end
 end # module MiqVimDataStore


### PR DESCRIPTION
Update the ruby version matrix to include 3.0 which shows a failure using `URI.encode` in the `MiqVimDataStore` class